### PR TITLE
Freeze AtomData entries on assignment

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+0.16.1
+------
+
+- :class:`~hofmann.StructureScene` ``atom_data`` arrays are now stored
+  read-only.  In-place mutation of a returned array raises
+  ``ValueError: assignment destination is read-only`` instead of
+  silently bypassing shape validation and cache invalidation.  Update
+  values by building a new array and reassigning the key.
+
 0.16.0
 ------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.16.1
+0.17.0
 ------
 
 - :class:`~hofmann.StructureScene` ``atom_data`` arrays are now stored

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hofmann"
-version = "0.16.0"
+version = "0.17.0"
 description = "A modern Python reimagining of the XBS ball-and-stick crystal structure viewer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -54,7 +54,7 @@ class AtomData(MutableMapping[str, np.ndarray]):
         return len(self._frames)
 
     def __setitem__(self, key: str, value: object) -> None:
-        arr = np.asarray(value)
+        arr = np.array(value)
         if arr.ndim == 1:
             if len(arr) != self._n_atoms:
                 raise ValueError(
@@ -77,6 +77,7 @@ class AtomData(MutableMapping[str, np.ndarray]):
                 f"atom_data[{key!r}] must be 1-D or 2-D, "
                 f"got {arr.ndim}-D"
             )
+        arr.flags.writeable = False
         self._data[key] = arr
         self._invalidate(key)
 

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -18,11 +18,12 @@ class AtomData(MutableMapping[str, np.ndarray]):
 
     .. note::
 
-       Arrays are returned by reference.  In-place mutation (e.g.
-       ``ad["charge"][0] = 99``) bypasses validation and does not
-       invalidate the :meth:`global_range` or :meth:`global_labels`
-       caches.  Re-assign the key
-       to trigger re-validation and cache invalidation.
+       Stored arrays are returned read-only.  In-place mutation (e.g.
+       ``ad["charge"][0] = 99``) raises
+       ``ValueError: assignment destination is read-only``.  To update
+       values, build a new array and reassign the key; reassignment
+       re-validates the shape and invalidates the
+       :meth:`global_range` and :meth:`global_labels` caches.
 
     The frame count is read live from the *frames* list so that arrays
     added after appending frames are validated against the current

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -13,9 +13,10 @@ class AtomData(MutableMapping[str, np.ndarray]):
     """Validated mapping of named per-atom arrays.
 
     Every value must be a numpy array of shape ``(n_atoms,)`` (static)
-    or ``(n_frames, n_atoms)`` (per-frame).  Arrays are validated on
-    assignment and array-likes are copied via :func:`numpy.array`
-    so the container owns the buffer.
+    or ``(n_frames, n_atoms)`` (per-frame).  Assigned values are always
+    copied via :func:`numpy.array` — including existing numpy arrays —
+    so the container owns the buffer and the caller's source array is
+    left untouched.
 
     .. note::
 
@@ -24,7 +25,9 @@ class AtomData(MutableMapping[str, np.ndarray]):
        ``ValueError: assignment destination is read-only``.  To update
        values, build a new array and reassign the key; reassignment
        re-validates the shape and invalidates the
-       :meth:`global_range` and :meth:`global_labels` caches.
+       :meth:`global_range` and :meth:`global_labels` caches.  Only
+       the array buffer is frozen — for ``object``-dtype arrays, any
+       mutable objects stored inside remain mutable.
 
     The frame count is read live from the *frames* list so that arrays
     added after appending frames are validated against the current

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -14,7 +14,8 @@ class AtomData(MutableMapping[str, np.ndarray]):
 
     Every value must be a numpy array of shape ``(n_atoms,)`` (static)
     or ``(n_frames, n_atoms)`` (per-frame).  Arrays are validated on
-    assignment and array-likes are converted via :func:`numpy.asarray`.
+    assignment and array-likes are copied via :func:`numpy.array`
+    so the container owns the buffer.
 
     .. note::
 

--- a/src/hofmann/model/structure_scene.py
+++ b/src/hofmann/model/structure_scene.py
@@ -129,6 +129,8 @@ class StructureScene:
         every frame) or a 2-D array of shape ``(n_frames, n_atoms)``
         (per-frame values).  Use :meth:`set_atom_data` to populate
         this and ``colour_by`` on the render methods to visualise it.
+        Stored arrays are returned read-only; see :class:`AtomData`
+        for how to update values.
         """
         return self._atom_data
 

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -29,7 +29,6 @@ class TestAtomData:
         ad = _make_atom_data(n_atoms=2, n_frames=1)
         ad["val"] = [1.0, 2.0]
         assert isinstance(ad["val"], np.ndarray)
-        assert ad["val"].flags.writeable is False
 
     def test_setitem_wrong_length_raises(self):
         ad = _make_atom_data(n_atoms=3, n_frames=1)
@@ -219,3 +218,22 @@ class TestAtomData:
         ad["site"] = np.array(["alpha", "beta"], dtype=object)
         with pytest.raises(ValueError, match="read-only"):
             ad["site"][0] = "gamma"
+
+    def test_setitem_list_input_stored_read_only(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=1)
+        ad["val"] = [1.0, 2.0]
+        with pytest.raises(ValueError, match="read-only"):
+            ad["val"][0] = 99.0
+
+    def test_setitem_augmented_assign_raises(self):
+        ad = _make_atom_data(n_atoms=3, n_frames=1)
+        ad["charge"] = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="read-only"):
+            ad["charge"] += 1.0
+
+    def test_setitem_view_of_stored_array_is_read_only(self):
+        ad = _make_atom_data(n_atoms=3, n_frames=1)
+        ad["charge"] = np.array([1.0, 2.0, 3.0])
+        view = ad["charge"][1:]
+        with pytest.raises(ValueError, match="read-only"):
+            view[0] = 99.0

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -190,7 +190,6 @@ class TestAtomData:
             arr[...] = 0.0
 
     def test_setitem_does_not_freeze_caller_source(self):
-        """Caller's array is neither aliased nor frozen by assignment."""
         ad = _make_atom_data(n_atoms=3, n_frames=1)
         src = np.array([1.0, 2.0, 3.0])
         ad["charge"] = src

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -169,3 +169,39 @@ class TestAtomData:
         # 2-D array with 2 rows now valid.
         ad["val"] = np.array([[1.0, 2.0], [3.0, 4.0]])
         assert ad["val"].shape == (2, 2)
+
+    def test_setitem_1d_stored_array_is_read_only(self):
+        ad = _make_atom_data(n_atoms=3, n_frames=1)
+        ad["charge"] = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="read-only"):
+            ad["charge"][0] = 99.0
+
+    def test_setitem_2d_stored_array_is_read_only(self):
+        ad = _make_atom_data(n_atoms=3, n_frames=2)
+        ad["charge"] = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        with pytest.raises(ValueError, match="read-only"):
+            ad["charge"][0, 0] = 99.0
+
+    def test_setitem_local_reference_is_read_only(self):
+        ad = _make_atom_data(n_atoms=3, n_frames=1)
+        ad["charge"] = np.array([1.0, 2.0, 3.0])
+        arr = ad["charge"]
+        with pytest.raises(ValueError, match="read-only"):
+            arr[...] = 0.0
+
+    def test_setitem_does_not_freeze_caller_source(self):
+        """Caller's array is neither aliased nor frozen by assignment."""
+        ad = _make_atom_data(n_atoms=3, n_frames=1)
+        src = np.array([1.0, 2.0, 3.0])
+        ad["charge"] = src
+        # Source is still writable.
+        assert src.flags.writeable is True
+        # Mutating the source does not affect the stored array.
+        src[0] = 99.0
+        assert ad["charge"][0] == 1.0
+
+    def test_setitem_reassignment_replaces_values(self):
+        ad = _make_atom_data(n_atoms=3, n_frames=1)
+        ad["charge"] = np.array([1.0, 2.0, 3.0])
+        ad["charge"] = np.array([4.0, 5.0, 6.0])
+        np.testing.assert_array_equal(ad["charge"], [4.0, 5.0, 6.0])

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -29,6 +29,7 @@ class TestAtomData:
         ad = _make_atom_data(n_atoms=2, n_frames=1)
         ad["val"] = [1.0, 2.0]
         assert isinstance(ad["val"], np.ndarray)
+        assert ad["val"].flags.writeable is False
 
     def test_setitem_wrong_length_raises(self):
         ad = _make_atom_data(n_atoms=3, n_frames=1)
@@ -204,3 +205,17 @@ class TestAtomData:
         ad["charge"] = np.array([1.0, 2.0, 3.0])
         ad["charge"] = np.array([4.0, 5.0, 6.0])
         np.testing.assert_array_equal(ad["charge"], [4.0, 5.0, 6.0])
+
+    def test_setitem_accepts_already_read_only_ndarray(self):
+        ad = _make_atom_data(n_atoms=3, n_frames=1)
+        src = np.array([1.0, 2.0, 3.0])
+        src.flags.writeable = False
+        ad["charge"] = src
+        assert ad["charge"].flags.writeable is False
+        np.testing.assert_array_equal(ad["charge"], [1.0, 2.0, 3.0])
+
+    def test_setitem_object_dtype_stored_array_is_read_only(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=1)
+        ad["site"] = np.array(["alpha", "beta"], dtype=object)
+        with pytest.raises(ValueError, match="read-only"):
+            ad["site"][0] = "gamma"


### PR DESCRIPTION
## Summary

- `AtomData.__setitem__` now copies the incoming array via `numpy.array` and sets `writeable = False` on the stored copy. In-place mutation of a returned array (e.g. `scene.atom_data["charge"][0] = 99`) now raises `ValueError: assignment destination is read-only` at the mutation site instead of silently bypassing shape validation and leaving the `global_range` / `global_labels` caches stale.
- To update values, callers build a new array and reassign the key; reassignment continues to validate the shape and invalidate the caches.
- Class docstring and changelog updated. Closes #64.