### PR TITLE
Retire AtomData range/labels caches for eager computation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -91,13 +91,11 @@ Colours and defaults
 
 .. autofunction:: normalise_colour
 
-.. autofunction:: resolve_atom_colours
-
 .. data:: CmapSpec
 
-   Type alias for colourmap specifications accepted by
-   :func:`resolve_atom_colours` and the ``cmap`` parameter of render
-   methods.  See the type definition in :mod:`hofmann.model` for details.
+   Type alias for colourmap specifications accepted by the ``cmap``
+   parameter of render methods.  See the type definition in
+   :mod:`hofmann.model` for details.
 
 .. data:: ELEMENT_COLOURS
    :type: dict[str, tuple[float, float, float]]

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.18.0
+------
+
+- :class:`~hofmann.AtomData` now exposes derived per-key metadata via
+  read-only mapping attributes ``ranges`` and ``labels``, replacing the
+  previous ``global_range()`` and ``global_labels()`` methods.  Callers
+  migrate with a direct substitution: ``ad.global_range(key)`` becomes
+  ``ad.ranges[key]``, and ``ad.global_labels(key)`` becomes
+  ``ad.labels[key]``.  The results are computed eagerly on assignment,
+  so every access is a simple dictionary lookup.
+
 0.17.0
 ------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,11 @@ Changelog
   other dtypes now raise :class:`ValueError` at assignment rather
   than failing later in the rendering pipeline.
 
+- ``resolve_atom_colours`` is no longer part of the public API.  It
+  was exposed before :class:`~hofmann.StructureScene` matured and
+  never developed a documented workflow; colour resolution should
+  go through the scene rendering methods.
+
 0.17.0
 ------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,10 +18,9 @@ Changelog
   other dtypes now raise :class:`ValueError` at assignment rather
   than failing later in the rendering pipeline.
 
-- ``resolve_atom_colours`` is no longer part of the public API.  It
-  was exposed before :class:`~hofmann.StructureScene` matured and
-  never developed a documented workflow; colour resolution should
-  go through the scene rendering methods.
+- ``resolve_atom_colours`` is no longer part of the public API.
+  Colour resolution goes through the :class:`~hofmann.StructureScene`
+  rendering methods.
 
 0.17.0
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -476,9 +476,9 @@ Changelog
   subsets; the first non-missing value wins for each atom.
 - Polyhedra without an explicit colour now inherit the resolved
   ``colour_by`` colour of their centre atom.
-- New public API: :func:`~hofmann.resolve_atom_colours` for
-  programmatic colour resolution, and :data:`~hofmann.CmapSpec` type
-  alias for colourmap specifications.
+- New public API: ``resolve_atom_colours`` for programmatic colour
+  resolution, and :data:`~hofmann.CmapSpec` type alias for colourmap
+  specifications.
 
 0.1.0
 -----

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,12 @@ Changelog
   ``ad.labels[key]``.  The results are computed eagerly on assignment,
   so every access is a simple dictionary lookup.
 
+- :class:`~hofmann.AtomData` rejects unsupported dtypes at assignment
+  time with a clear error message.  Supported dtypes are bool,
+  integer, float, string, and object; complex, datetime, bytes, and
+  other dtypes now raise :class:`ValueError` at assignment rather
+  than failing later in the rendering pipeline.
+
 0.17.0
 ------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hofmann"
-version = "0.17.0"
+version = "0.18.0"
 description = "A modern Python reimagining of the XBS ball-and-stick crystal structure viewer"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hofmann/__init__.py
+++ b/src/hofmann/__init__.py
@@ -42,7 +42,6 @@ from hofmann.model import (
     ViewState,
     WidgetCorner,
     normalise_colour,
-    resolve_atom_colours,
 )
 from hofmann.construction.scene_builders import from_ase, from_pymatgen, from_xbs
 from hofmann.construction.styles import StyleSet, load_styles, save_styles
@@ -81,6 +80,5 @@ __all__ = [
     "from_xbs",
     "load_styles",
     "normalise_colour",
-    "resolve_atom_colours",
     "save_styles",
 ]

--- a/src/hofmann/model/__init__.py
+++ b/src/hofmann/model/__init__.py
@@ -12,7 +12,6 @@ from hofmann.model.colour import (
     CmapSpec,
     Colour,
     normalise_colour,
-    resolve_atom_colours,
 )
 from hofmann.model.frame import Frame
 from hofmann.model.polyhedron_spec import Polyhedron, PolyhedronSpec
@@ -56,5 +55,4 @@ __all__ = [
     "ViewState",
     "WidgetCorner",
     "normalise_colour",
-    "resolve_atom_colours",
 ]

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -16,9 +16,11 @@ def _compute_global_range(
     """Compute the global ``(min, max)`` for a 2-D numeric array.
 
     Returns ``None`` for 1-D arrays, categorical (string/object)
-    dtypes, or arrays where every value is NaN.
+    dtypes, empty arrays, or arrays where every value is NaN.
     """
     if arr.ndim != 2 or arr.dtype.kind in ("U", "O"):
+        return None
+    if arr.size == 0:
         return None
     with np.errstate(all="ignore"):
         lo = float(np.nanmin(arr))
@@ -28,8 +30,8 @@ def _compute_global_range(
     return (lo, hi)
 
 
-def _compute_global_labels(arr: np.ndarray) -> list[str] | None:
-    """Return the unique non-missing labels across all frames.
+def _compute_global_labels(arr: np.ndarray) -> tuple[str, ...] | None:
+    """Return the unique non-missing labels in a 2-D categorical array.
 
     Returns ``None`` for 1-D arrays or non-categorical (numeric)
     dtypes.  Missing values (``None``, ``""``, NaN) are excluded.
@@ -45,7 +47,7 @@ def _compute_global_labels(arr: np.ndarray) -> list[str] | None:
             seen[s] = None
     if not seen:
         return None
-    return list(seen)
+    return tuple(seen)
 
 
 class AtomData(MutableMapping[str, np.ndarray]):
@@ -78,14 +80,17 @@ class AtomData(MutableMapping[str, np.ndarray]):
         ranges: Read-only mapping of keys to ``(min, max)`` tuples
             for 2-D numeric arrays, or ``None`` for keys that do not
             have a meaningful numeric range (1-D arrays, categorical
-            dtypes, all-NaN numeric arrays).  Populated eagerly on
-            assignment and updated on reassignment or deletion.
-        labels: Read-only mapping of keys to lists of unique
+            dtypes, empty arrays, all-NaN numeric arrays).  Entries
+            are added on assignment, replaced on reassignment, and
+            removed on deletion.
+        labels: Read-only mapping of keys to tuples of unique
             non-missing categorical labels across all frames, or
             ``None`` for keys without a meaningful label set (1-D
             arrays, numeric dtypes, categorical arrays with no
-            non-missing values).  Populated eagerly on assignment
-            and updated on reassignment or deletion.
+            non-missing values).  Missing values (``None``, ``""``,
+            NaN) are excluded from the label set.  Entries are added
+            on assignment, replaced on reassignment, and removed on
+            deletion.
 
     Args:
         n_atoms: Number of atoms in the scene.
@@ -100,11 +105,11 @@ class AtomData(MutableMapping[str, np.ndarray]):
         self._frames = frames
         self._data: dict[str, np.ndarray] = {}
         self._ranges: dict[str, tuple[float, float] | None] = {}
-        self._labels: dict[str, list[str] | None] = {}
-        self.ranges: Mapping[str, tuple[float, float] | None] = (
+        self._labels: dict[str, tuple[str, ...] | None] = {}
+        self._ranges_view: Mapping[str, tuple[float, float] | None] = (
             MappingProxyType(self._ranges)
         )
-        self.labels: Mapping[str, list[str] | None] = (
+        self._labels_view: Mapping[str, tuple[str, ...] | None] = (
             MappingProxyType(self._labels)
         )
 
@@ -115,6 +120,14 @@ class AtomData(MutableMapping[str, np.ndarray]):
     @property
     def n_frames(self) -> int:
         return len(self._frames)
+
+    @property
+    def ranges(self) -> Mapping[str, tuple[float, float] | None]:
+        return self._ranges_view
+
+    @property
+    def labels(self) -> Mapping[str, tuple[str, ...] | None]:
+        return self._labels_view
 
     def __setitem__(self, key: str, value: object) -> None:
         arr = np.array(value)
@@ -141,9 +154,11 @@ class AtomData(MutableMapping[str, np.ndarray]):
                 f"got {arr.ndim}-D"
             )
         arr.flags.writeable = False
+        new_range = _compute_global_range(arr)
+        new_labels = _compute_global_labels(arr)
         self._data[key] = arr
-        self._ranges[key] = _compute_global_range(arr)
-        self._labels[key] = _compute_global_labels(arr)
+        self._ranges[key] = new_range
+        self._labels[key] = new_labels
 
     def __getitem__(self, key: str) -> np.ndarray:
         return self._data[key]

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -15,10 +15,11 @@ def _compute_global_range(
 ) -> tuple[float, float] | None:
     """Compute the global ``(min, max)`` for a 2-D numeric array.
 
-    Returns ``None`` for 1-D arrays, categorical (string/object)
-    dtypes, empty arrays, or arrays where every value is NaN.
+    Returns ``None`` for 1-D arrays, non-numeric dtypes (anything
+    other than bool, int, or float), empty arrays, or arrays where
+    every value is NaN.
     """
-    if arr.ndim != 2 or arr.dtype.kind in ("U", "O"):
+    if arr.ndim != 2 or arr.dtype.kind not in ("b", "i", "u", "f"):
         return None
     if arr.size == 0:
         return None
@@ -79,10 +80,12 @@ class AtomData(MutableMapping[str, np.ndarray]):
     Attributes:
         ranges: Read-only mapping of keys to ``(min, max)`` tuples
             for 2-D numeric arrays, or ``None`` for keys that do not
-            have a meaningful numeric range (1-D arrays, categorical
-            dtypes, empty arrays, all-NaN numeric arrays).  Entries
-            are added on assignment, replaced on reassignment, and
-            removed on deletion.
+            have a meaningful numeric range (1-D arrays, non-numeric
+            dtypes, empty arrays, all-NaN numeric arrays).  "Numeric"
+            here means bool, integer, or floating-point; complex,
+            datetime, bytes, and other dtypes are stored without a
+            computed range.  Entries are added on assignment,
+            replaced on reassignment, and removed on deletion.
         labels: Read-only mapping of keys to tuples of unique
             non-missing categorical labels across all frames, or
             ``None`` for keys without a meaningful label set (1-D

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -35,6 +35,14 @@ def _compute_global_labels(arr: np.ndarray) -> tuple[str, ...] | None:
 
     Returns ``None`` for 1-D arrays or non-categorical (numeric)
     dtypes.  Missing values (``None``, ``""``, NaN) are excluded.
+
+    Labels are returned in first-encountered order across
+    ``arr.ravel()``.  This ordering is load-bearing: downstream
+    colourmap assignment (``_resolve_categorical``) indexes into this
+    tuple via :func:`enumerate`, so the order determines which label
+    gets which colour.  Preserve the insertion-order semantics;
+    sorting or otherwise reordering the result will silently change
+    per-atom colours.
     """
     if arr.ndim != 2 or arr.dtype.kind not in ("U", "O"):
         return None

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -15,11 +15,10 @@ def _compute_global_range(
 ) -> tuple[float, float] | None:
     """Compute the global ``(min, max)`` for a 2-D numeric array.
 
-    Returns ``None`` for 1-D arrays, non-numeric dtypes (anything
-    other than bool, int, or float), empty arrays, or arrays where
-    every value is NaN.
+    Returns ``None`` for 1-D arrays, categorical (string/object)
+    dtypes, empty arrays, or arrays where every value is NaN.
     """
-    if arr.ndim != 2 or arr.dtype.kind not in ("b", "i", "u", "f"):
+    if arr.ndim != 2 or arr.dtype.kind in ("U", "O"):
         return None
     if arr.size == 0:
         return None
@@ -80,12 +79,10 @@ class AtomData(MutableMapping[str, np.ndarray]):
     Attributes:
         ranges: Read-only mapping of keys to ``(min, max)`` tuples
             for 2-D numeric arrays, or ``None`` for keys that do not
-            have a meaningful numeric range (1-D arrays, non-numeric
-            dtypes, empty arrays, all-NaN numeric arrays).  "Numeric"
-            here means bool, integer, or floating-point; complex,
-            datetime, bytes, and other dtypes are stored without a
-            computed range.  Entries are added on assignment,
-            replaced on reassignment, and removed on deletion.
+            have a meaningful numeric range (1-D arrays, categorical
+            arrays, empty arrays, all-NaN numeric arrays).  Entries
+            are added on assignment, replaced on reassignment, and
+            removed on deletion.
         labels: Read-only mapping of keys to tuples of unique
             non-missing categorical labels across all frames, or
             ``None`` for keys without a meaningful label set (1-D
@@ -155,6 +152,12 @@ class AtomData(MutableMapping[str, np.ndarray]):
             raise ValueError(
                 f"atom_data[{key!r}] must be 1-D or 2-D, "
                 f"got {arr.ndim}-D"
+            )
+        if arr.dtype.kind not in ("b", "i", "u", "f", "U", "O"):
+            raise ValueError(
+                f"atom_data[{key!r}] has unsupported dtype "
+                f"{arr.dtype}; supported dtypes are bool, integer, "
+                f"float, string, and object"
             )
         arr.flags.writeable = False
         new_range = _compute_global_range(arr)

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -9,6 +9,44 @@ import numpy as np
 from hofmann.model.colour import _is_categorical_missing
 
 
+def _compute_global_range(
+    arr: np.ndarray,
+) -> tuple[float, float] | None:
+    """Compute the global ``(min, max)`` for a 2-D numeric array.
+
+    Returns ``None`` for 1-D arrays, categorical (string/object)
+    dtypes, or arrays where every value is NaN.
+    """
+    if arr.ndim != 2 or arr.dtype.kind in ("U", "O"):
+        return None
+    with np.errstate(all="ignore"):
+        lo = float(np.nanmin(arr))
+        hi = float(np.nanmax(arr))
+    if np.isnan(lo):
+        return None
+    return (lo, hi)
+
+
+def _compute_global_labels(arr: np.ndarray) -> list[str] | None:
+    """Return the unique non-missing labels across all frames.
+
+    Returns ``None`` for 1-D arrays or non-categorical (numeric)
+    dtypes.  Missing values (``None``, ``""``, NaN) are excluded.
+    """
+    if arr.ndim != 2 or arr.dtype.kind not in ("U", "O"):
+        return None
+    seen: dict[str, None] = {}
+    for v in arr.ravel():
+        if _is_categorical_missing(v):
+            continue
+        s = str(v)
+        if s not in seen:
+            seen[s] = None
+    if not seen:
+        return None
+    return list(seen)
+
+
 class AtomData(MutableMapping[str, np.ndarray]):
     """Validated mapping of named per-atom arrays.
 
@@ -47,8 +85,8 @@ class AtomData(MutableMapping[str, np.ndarray]):
         self._n_atoms = n_atoms
         self._frames = frames
         self._data: dict[str, np.ndarray] = {}
-        self._range_cache: dict[str, tuple[float, float] | None] = {}
-        self._labels_cache: dict[str, list[str] | None] = {}
+        self._ranges: dict[str, tuple[float, float] | None] = {}
+        self._labels: dict[str, list[str] | None] = {}
 
     @property
     def n_atoms(self) -> int:
@@ -84,19 +122,16 @@ class AtomData(MutableMapping[str, np.ndarray]):
             )
         arr.flags.writeable = False
         self._data[key] = arr
-        self._invalidate(key)
-
-    def _invalidate(self, key: str) -> None:
-        """Clear cached global_range / global_labels for *key*."""
-        self._range_cache.pop(key, None)
-        self._labels_cache.pop(key, None)
+        self._ranges[key] = _compute_global_range(arr)
+        self._labels[key] = _compute_global_labels(arr)
 
     def __getitem__(self, key: str) -> np.ndarray:
         return self._data[key]
 
     def __delitem__(self, key: str) -> None:
         del self._data[key]
-        self._invalidate(key)
+        del self._ranges[key]
+        del self._labels[key]
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._data)
@@ -107,53 +142,19 @@ class AtomData(MutableMapping[str, np.ndarray]):
     def global_range(self, key: str) -> tuple[float, float] | None:
         """Return the global ``(min, max)`` for a 2-D numeric array.
 
-        The result is cached and invalidated when the key is reassigned
-        or deleted.  Returns ``None`` for 1-D arrays, categorical
-        (string/object) arrays, or arrays where every value is NaN.
+        Returns ``None`` for 1-D arrays, categorical (string/object)
+        arrays, or arrays where every value is NaN.
         """
-        if key in self._range_cache:
-            return self._range_cache[key]
-        arr = self._data[key]
-        if arr.ndim != 2 or arr.dtype.kind in ("U", "O"):
-            self._range_cache[key] = None
-            return None
-        with np.errstate(all="ignore"):
-            lo = float(np.nanmin(arr))
-            hi = float(np.nanmax(arr))
-        if np.isnan(lo):
-            self._range_cache[key] = None
-            return None
-        result = (lo, hi)
-        self._range_cache[key] = result
-        return result
+        return self._ranges[key]
 
     def global_labels(self, key: str) -> list[str] | None:
         """Return the unique non-missing labels across all frames.
 
-        The result is cached and invalidated when the key is reassigned
-        or deleted.  Returns ``None`` for 1-D arrays or non-categorical
-        (numeric) arrays.  Missing values (``None``, ``""``, ``NaN``)
-        are excluded.
+        Returns ``None`` for 1-D arrays or non-categorical (numeric)
+        arrays.  Missing values (``None``, ``""``, ``NaN``) are
+        excluded.
         """
-        if key in self._labels_cache:
-            return self._labels_cache[key]
-        arr = self._data[key]
-        if arr.ndim != 2 or arr.dtype.kind not in ("U", "O"):
-            self._labels_cache[key] = None
-            return None
-        seen: dict[str, None] = {}
-        for v in arr.ravel():
-            if _is_categorical_missing(v):
-                continue
-            s = str(v)
-            if s not in seen:
-                seen[s] = None
-        if not seen:
-            self._labels_cache[key] = None
-            return None
-        result = list(seen)
-        self._labels_cache[key] = result
-        return result
+        return self._labels[key]
 
     def __repr__(self) -> str:
         keys = ", ".join(repr(k) for k in self._data)

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -100,10 +100,11 @@ class AtomData(MutableMapping[str, np.ndarray]):
             on assignment, replaced on reassignment, and removed on
             deletion.
 
-    For 2-D arrays, exactly one of ``ranges[key]`` and
-    ``labels[key]`` holds a value, depending on dtype: numeric
-    arrays populate ``ranges``, categorical arrays populate
-    ``labels``.  For 1-D arrays, both are ``None``.
+    For 2-D arrays, ``ranges`` is populated for numeric dtypes and
+    ``labels`` for categorical dtypes; the other side is always
+    ``None``.  Either side may itself be ``None`` for empty arrays
+    or arrays containing only missing values.  For 1-D arrays, both
+    are ``None``.
 
     Args:
         n_atoms: Number of atoms in the scene.

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -100,6 +100,11 @@ class AtomData(MutableMapping[str, np.ndarray]):
             on assignment, replaced on reassignment, and removed on
             deletion.
 
+    For 2-D arrays, exactly one of ``ranges[key]`` and
+    ``labels[key]`` holds a value, depending on dtype: numeric
+    arrays populate ``ranges``, categorical arrays populate
+    ``labels``.  For 1-D arrays, both are ``None``.
+
     Args:
         n_atoms: Number of atoms in the scene.
         frames: The scene's live frame list.  The length of this list

--- a/src/hofmann/model/atom_data.py
+++ b/src/hofmann/model/atom_data.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator, MutableMapping
+from collections.abc import Iterator, Mapping, MutableMapping
+from types import MappingProxyType
 
 import numpy as np
 
@@ -62,16 +63,29 @@ class AtomData(MutableMapping[str, np.ndarray]):
        ``ad["charge"][0] = 99``) raises
        ``ValueError: assignment destination is read-only``.  To update
        values, build a new array and reassign the key; reassignment
-       re-validates the shape and invalidates the
-       :meth:`global_range` and :meth:`global_labels` caches.  Only
-       the array buffer is frozen — for ``object``-dtype arrays, any
-       mutable objects stored inside remain mutable.
+       re-validates the shape and recomputes the :attr:`ranges` and
+       :attr:`labels` entries.  Only the array buffer is frozen — for
+       ``object``-dtype arrays, any mutable objects stored inside
+       remain mutable.
 
     The frame count is read live from the *frames* list so that arrays
     added after appending frames are validated against the current
     trajectory length.  However, existing 2-D arrays are not
     re-validated when frames are appended — re-assign them after
     changing the trajectory length.
+
+    Attributes:
+        ranges: Read-only mapping of keys to ``(min, max)`` tuples
+            for 2-D numeric arrays, or ``None`` for keys that do not
+            have a meaningful numeric range (1-D arrays, categorical
+            dtypes, all-NaN numeric arrays).  Populated eagerly on
+            assignment and updated on reassignment or deletion.
+        labels: Read-only mapping of keys to lists of unique
+            non-missing categorical labels across all frames, or
+            ``None`` for keys without a meaningful label set (1-D
+            arrays, numeric dtypes, categorical arrays with no
+            non-missing values).  Populated eagerly on assignment
+            and updated on reassignment or deletion.
 
     Args:
         n_atoms: Number of atoms in the scene.
@@ -87,6 +101,12 @@ class AtomData(MutableMapping[str, np.ndarray]):
         self._data: dict[str, np.ndarray] = {}
         self._ranges: dict[str, tuple[float, float] | None] = {}
         self._labels: dict[str, list[str] | None] = {}
+        self.ranges: Mapping[str, tuple[float, float] | None] = (
+            MappingProxyType(self._ranges)
+        )
+        self.labels: Mapping[str, list[str] | None] = (
+            MappingProxyType(self._labels)
+        )
 
     @property
     def n_atoms(self) -> int:
@@ -138,23 +158,6 @@ class AtomData(MutableMapping[str, np.ndarray]):
 
     def __len__(self) -> int:
         return len(self._data)
-
-    def global_range(self, key: str) -> tuple[float, float] | None:
-        """Return the global ``(min, max)`` for a 2-D numeric array.
-
-        Returns ``None`` for 1-D arrays, categorical (string/object)
-        arrays, or arrays where every value is NaN.
-        """
-        return self._ranges[key]
-
-    def global_labels(self, key: str) -> list[str] | None:
-        """Return the unique non-missing labels across all frames.
-
-        Returns ``None`` for 1-D arrays or non-categorical (numeric)
-        arrays.  Missing values (``None``, ``""``, ``NaN``) are
-        excluded.
-        """
-        return self._labels[key]
 
     def __repr__(self) -> str:
         keys = ", ".join(repr(k) for k in self._data)

--- a/src/hofmann/model/colour.py
+++ b/src/hofmann/model/colour.py
@@ -143,10 +143,10 @@ def _resolve_single_layer(
 
     Args:
         scene_atom_data: The scene's :class:`AtomData` container.
-            When provided, cached global metadata is used for 2-D
+            When provided, derived global metadata is used for 2-D
             data so that colouring is consistent across animation
-            frames: :meth:`AtomData.global_range` for numeric data
-            and :meth:`AtomData.global_labels` for categorical data.
+            frames: :attr:`AtomData.ranges` for numeric data and
+            :attr:`AtomData.labels` for categorical data.
 
     Returns:
         A tuple of ``(colours, missing_mask)`` where *colours* is a
@@ -159,10 +159,10 @@ def _resolve_single_layer(
     if values.dtype.kind in ("U", "O"):
         labels = None
         if scene_atom_data is not None:
-            labels = scene_atom_data.global_labels(key)
+            labels = scene_atom_data.labels[key]
         return _resolve_categorical(values, fallback, cmap_fn, labels)
     if colour_range is None and scene_atom_data is not None:
-        colour_range = scene_atom_data.global_range(key)
+        colour_range = scene_atom_data.ranges[key]
     return _resolve_numerical(values, fallback, cmap_fn, colour_range)
 
 
@@ -365,9 +365,8 @@ def _resolve_categorical(
     Args:
         global_labels: When provided, these labels define the
             colourmap positions (consistent across animation frames).
-            Typically computed by :meth:`AtomData.global_labels`,
-            which scans all frames so every per-frame label is
-            included.
+            Typically looked up via :attr:`AtomData.labels`, which
+            holds unique labels across all frames.
 
     Returns:
         A tuple of ``(colours, missing_mask)`` where *missing_mask* is

--- a/src/hofmann/model/colour.py
+++ b/src/hofmann/model/colour.py
@@ -155,12 +155,6 @@ def _resolve_single_layer(
         (which received their species fallback colour).
     """
     values = atom_data[key]
-    if values.dtype.kind not in ("b", "i", "u", "f", "U", "O"):
-        raise ValueError(
-            f"atom_data[{key!r}] has unsupported dtype "
-            f"{values.dtype} for colouring; supported dtypes are "
-            f"bool, integer, float, string, and object"
-        )
     cmap_fn = _resolve_cmap(cmap)
     if values.dtype.kind in ("U", "O"):
         labels = None
@@ -172,7 +166,7 @@ def _resolve_single_layer(
     return _resolve_numerical(values, fallback, cmap_fn, colour_range)
 
 
-def resolve_atom_colours(
+def _resolve_atom_colours(
     species: list[str],
     atom_styles: dict[str, AtomStyle],
     atom_data: dict[str, np.ndarray],

--- a/src/hofmann/model/colour.py
+++ b/src/hofmann/model/colour.py
@@ -311,6 +311,11 @@ def _resolve_numerical(
         a boolean array that is ``True`` for atoms whose values are
         NaN.
     """
+    if values.dtype.kind not in ("b", "i", "u", "f"):
+        raise ValueError(
+            f"_resolve_numerical requires a numeric dtype "
+            f"(bool, integer, or float), got {values.dtype}"
+        )
     values = values.astype(float, copy=False)
     mask = np.isnan(values)
 

--- a/src/hofmann/model/colour.py
+++ b/src/hofmann/model/colour.py
@@ -212,8 +212,9 @@ def resolve_atom_colours(
             list, may also be a list of the same length.
         scene_atom_data: The scene's :class:`AtomData` container.
             When provided and a key's *colour_range* is ``None``,
-            the cached global range is used for 2-D numeric data
-            so that colourmap scaling is consistent across frames.
+            the derived global range from :attr:`AtomData.ranges`
+            is used for 2-D numeric data so that colourmap scaling
+            is consistent across frames.
 
     Returns:
         List of ``(r, g, b)`` tuples, one per atom.

--- a/src/hofmann/model/colour.py
+++ b/src/hofmann/model/colour.py
@@ -356,7 +356,7 @@ def _resolve_categorical(
     values: np.ndarray,
     fallback: list[tuple[float, float, float]],
     cmap_fn: Callable[[float], tuple[float, float, float]],
-    global_labels: list[str] | None = None,
+    global_labels: tuple[str, ...] | None = None,
 ) -> tuple[list[tuple[float, float, float]], np.ndarray]:
     """Map categorical labels through a colourmap.
 

--- a/src/hofmann/model/colour.py
+++ b/src/hofmann/model/colour.py
@@ -155,6 +155,12 @@ def _resolve_single_layer(
         (which received their species fallback colour).
     """
     values = atom_data[key]
+    if values.dtype.kind not in ("b", "i", "u", "f", "U", "O"):
+        raise ValueError(
+            f"atom_data[{key!r}] has unsupported dtype "
+            f"{values.dtype} for colouring; supported dtypes are "
+            f"bool, integer, float, string, and object"
+        )
     cmap_fn = _resolve_cmap(cmap)
     if values.dtype.kind in ("U", "O"):
         labels = None

--- a/src/hofmann/rendering/precompute.py
+++ b/src/hofmann/rendering/precompute.py
@@ -29,8 +29,8 @@ from hofmann.model import (
     SlabClipMode,
     StructureScene,
     normalise_colour,
-    resolve_atom_colours,
 )
+from hofmann.model.colour import _resolve_atom_colours
 from hofmann._constants import DEFAULT_ATOM_RADIUS
 
 
@@ -207,7 +207,7 @@ def _precompute_scene(
 
     radii_3d = _compute_atom_radii(species, scene.atom_styles)
 
-    atom_colours = resolve_atom_colours(
+    atom_colours = _resolve_atom_colours(
         species, scene.atom_styles, atom_data,
         colour_by=colour_by, cmap=cmap, colour_range=colour_range,
         scene_atom_data=scene.atom_data,

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -144,9 +144,9 @@ class TestAtomData:
     def test_ranges_is_read_only(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
-        with pytest.raises(TypeError, match="mappingproxy"):
+        with pytest.raises(TypeError):
             ad.ranges["val"] = (0.0, 99.0)
-        with pytest.raises(TypeError, match="mappingproxy"):
+        with pytest.raises(TypeError):
             del ad.ranges["val"]
 
     def test_ranges_attribute_cannot_be_rebound(self):
@@ -175,8 +175,7 @@ class TestAtomData:
             ad.ranges["nonexistent"]
 
     def test_ranges_empty_2d_returns_none(self):
-        frames: list = [None, None]  # type: ignore[list-item]
-        ad = AtomData(n_atoms=0, frames=frames)
+        ad = _make_atom_data(n_atoms=0, n_frames=2)
         ad["val"] = np.empty((2, 0))
         assert ad.ranges["val"] is None
 
@@ -212,9 +211,9 @@ class TestAtomData:
     def test_labels_is_read_only(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
-        with pytest.raises(TypeError, match="mappingproxy"):
+        with pytest.raises(TypeError):
             ad.labels["site"] = ("x", "y")
-        with pytest.raises(TypeError, match="mappingproxy"):
+        with pytest.raises(TypeError):
             del ad.labels["site"]
 
     def test_labels_attribute_cannot_be_rebound(self):

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -180,20 +180,25 @@ class TestAtomData:
         ad["val"] = np.empty((2, 0))
         assert ad.ranges["val"] is None
 
-    def test_ranges_complex_dtype_returns_none(self):
+    def test_setitem_complex_dtype_raises(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
-        ad["z"] = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
-        assert ad.ranges["z"] is None
+        with pytest.raises(ValueError, match="unsupported dtype"):
+            ad["z"] = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
 
-    def test_ranges_datetime_dtype_returns_none(self):
+    def test_setitem_datetime_dtype_raises(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
-        ad["t"] = np.array(
-            [
-                [np.datetime64("2024-01-01"), np.datetime64("2024-01-02")],
-                [np.datetime64("2024-01-03"), np.datetime64("2024-01-04")],
-            ]
-        )
-        assert ad.ranges["t"] is None
+        with pytest.raises(ValueError, match="unsupported dtype"):
+            ad["t"] = np.array(
+                [
+                    [np.datetime64("2024-01-01"), np.datetime64("2024-01-02")],
+                    [np.datetime64("2024-01-03"), np.datetime64("2024-01-04")],
+                ]
+            )
+
+    def test_setitem_bytes_dtype_raises(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=1)
+        with pytest.raises(ValueError, match="unsupported dtype"):
+            ad["site"] = np.array([b"foo", b"bar"])
 
     def test_ranges_contains_every_stored_key(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -179,25 +179,21 @@ class TestAtomData:
         ad["val"] = np.empty((2, 0))
         assert ad.ranges["val"] is None
 
-    def test_setitem_complex_dtype_raises(self):
-        ad = _make_atom_data(n_atoms=2, n_frames=2)
-        with pytest.raises(ValueError, match="unsupported dtype"):
-            ad["z"] = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
-
-    def test_setitem_datetime_dtype_raises(self):
-        ad = _make_atom_data(n_atoms=2, n_frames=2)
-        with pytest.raises(ValueError, match="unsupported dtype"):
-            ad["t"] = np.array(
-                [
-                    [np.datetime64("2024-01-01"), np.datetime64("2024-01-02")],
-                    [np.datetime64("2024-01-03"), np.datetime64("2024-01-04")],
-                ]
-            )
-
-    def test_setitem_bytes_dtype_raises(self):
+    @pytest.mark.parametrize(
+        "array",
+        [
+            np.array([1 + 2j, 3 + 4j]),
+            np.array([np.datetime64("2024-01-01"), np.datetime64("2024-01-02")]),
+            np.array([np.timedelta64(1, "D"), np.timedelta64(2, "D")]),
+            np.array([b"foo", b"bar"]),
+            np.array([(1.0, "a"), (2.0, "b")], dtype=[("x", "f8"), ("y", "U5")]),
+        ],
+        ids=["complex", "datetime", "timedelta", "bytes", "void"],
+    )
+    def test_setitem_unsupported_dtype_raises(self, array):
         ad = _make_atom_data(n_atoms=2, n_frames=1)
         with pytest.raises(ValueError, match="unsupported dtype"):
-            ad["site"] = np.array([b"foo", b"bar"])
+            ad["key"] = array
 
     def test_ranges_contains_every_stored_key(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -111,7 +111,7 @@ class TestAtomData:
     def test_labels_2d_categorical(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["site"] = np.array([["alpha", "beta"], ["beta", "gamma"]], dtype=object)
-        assert ad.labels["site"] == ["alpha", "beta", "gamma"]
+        assert ad.labels["site"] == ("alpha", "beta", "gamma")
 
     def test_labels_1d_returns_none(self):
         ad = _make_atom_data(n_atoms=2, n_frames=1)
@@ -127,14 +127,14 @@ class TestAtomData:
         ad = _make_atom_data(n_atoms=3, n_frames=2)
         ad["site"] = np.array([["alpha", None, "beta"],
                                 [None, "alpha", None]], dtype=object)
-        assert ad.labels["site"] == ["alpha", "beta"]
+        assert ad.labels["site"] == ("alpha", "beta")
 
     def test_labels_updates_on_reassignment(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["site"] = np.array([["a", "b"], ["b", "a"]], dtype=object)
-        assert ad.labels["site"] == ["a", "b"]
+        assert ad.labels["site"] == ("a", "b")
         ad["site"] = np.array([["x", "y"], ["y", "x"]], dtype=object)
-        assert ad.labels["site"] == ["x", "y"]
+        assert ad.labels["site"] == ("x", "y")
 
     def test_ranges_partial_nan(self):
         ad = _make_atom_data(n_atoms=3, n_frames=2)
@@ -144,16 +144,41 @@ class TestAtomData:
     def test_ranges_is_read_only(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="mappingproxy"):
             ad.ranges["val"] = (0.0, 99.0)
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="mappingproxy"):
             del ad.ranges["val"]
+
+    def test_ranges_attribute_cannot_be_rebound(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        with pytest.raises(AttributeError):
+            ad.ranges = {}  # type: ignore[misc]
+
+    def test_ranges_identity_stable_across_accesses(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
+        first = ad.ranges
+        ad["other"] = np.array([[4.0, 5.0], [6.0, 7.0]])
+        assert ad.ranges is first
+
+    def test_ranges_captured_reference_sees_later_updates(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        captured = ad.ranges
+        ad["new"] = np.array([[0.0, 1.0], [2.0, 3.0]])
+        assert "new" in captured
+        assert captured["new"] == (0.0, 3.0)
 
     def test_ranges_missing_key_raises(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
         with pytest.raises(KeyError):
             ad.ranges["nonexistent"]
+
+    def test_ranges_empty_2d_returns_none(self):
+        frames: list = [None, None]  # type: ignore[list-item]
+        ad = AtomData(n_atoms=0, frames=frames)
+        ad["val"] = np.empty((2, 0))
+        assert ad.ranges["val"] is None
 
     def test_ranges_contains_every_stored_key(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
@@ -167,10 +192,15 @@ class TestAtomData:
     def test_labels_is_read_only(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
-        with pytest.raises(TypeError):
-            ad.labels["site"] = ["x", "y"]
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="mappingproxy"):
+            ad.labels["site"] = ("x", "y")
+        with pytest.raises(TypeError, match="mappingproxy"):
             del ad.labels["site"]
+
+    def test_labels_attribute_cannot_be_rebound(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        with pytest.raises(AttributeError):
+            ad.labels = {}  # type: ignore[misc]
 
     def test_labels_missing_key_raises(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -180,6 +180,21 @@ class TestAtomData:
         ad["val"] = np.empty((2, 0))
         assert ad.ranges["val"] is None
 
+    def test_ranges_complex_dtype_returns_none(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["z"] = np.array([[1 + 2j, 3 + 4j], [5 + 6j, 7 + 8j]])
+        assert ad.ranges["z"] is None
+
+    def test_ranges_datetime_dtype_returns_none(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["t"] = np.array(
+            [
+                [np.datetime64("2024-01-01"), np.datetime64("2024-01-02")],
+                [np.datetime64("2024-01-03"), np.datetime64("2024-01-04")],
+            ]
+        )
+        assert ad.ranges["t"] is None
+
     def test_ranges_contains_every_stored_key(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -154,13 +154,6 @@ class TestAtomData:
         with pytest.raises(AttributeError):
             ad.ranges = {}  # type: ignore[misc]
 
-    def test_ranges_identity_stable_across_accesses(self):
-        ad = _make_atom_data(n_atoms=2, n_frames=2)
-        ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
-        first = ad.ranges
-        ad["other"] = np.array([[4.0, 5.0], [6.0, 7.0]])
-        assert ad.ranges is first
-
     def test_ranges_captured_reference_sees_later_updates(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         captured = ad.ranges

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -73,87 +73,115 @@ class TestAtomData:
         with pytest.raises(ValueError):
             ad["bad"] = np.ones((2, 2, 2))
 
-    def test_global_range_2d_numeric(self):
+    def test_ranges_2d_numeric(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[0.0, 1.0], [0.4, 0.6]])
-        assert ad.global_range("val") == (0.0, 1.0)
+        assert ad.ranges["val"] == (0.0, 1.0)
 
-    def test_global_range_1d_returns_none(self):
+    def test_ranges_1d_returns_none(self):
         ad = _make_atom_data(n_atoms=2, n_frames=1)
         ad["val"] = np.array([0.0, 1.0])
-        assert ad.global_range("val") is None
+        assert ad.ranges["val"] is None
 
-    def test_global_range_categorical_returns_none(self):
+    def test_ranges_categorical_returns_none(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
-        assert ad.global_range("site") is None
+        assert ad.ranges["site"] is None
 
-    def test_global_range_all_nan_returns_none(self):
+    def test_ranges_all_nan_returns_none(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.full((2, 2), np.nan)
-        assert ad.global_range("val") is None
+        assert ad.ranges["val"] is None
 
-    def test_global_range_cached(self):
+    def test_ranges_updates_on_reassignment(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
-        r1 = ad.global_range("val")
-        r2 = ad.global_range("val")
-        assert r1 is r2  # same object from cache
-
-    def test_global_range_invalidated_on_set(self):
-        ad = _make_atom_data(n_atoms=2, n_frames=2)
-        ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
-        assert ad.global_range("val") == (0.0, 3.0)
+        assert ad.ranges["val"] == (0.0, 3.0)
         ad["val"] = np.array([[10.0, 20.0], [30.0, 40.0]])
-        assert ad.global_range("val") == (10.0, 40.0)
+        assert ad.ranges["val"] == (10.0, 40.0)
 
-    def test_global_range_invalidated_on_delete(self):
+    def test_ranges_recomputed_after_delete_and_reassign(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
-        assert ad.global_range("val") == (0.0, 3.0)
+        assert ad.ranges["val"] == (0.0, 3.0)
         del ad["val"]
         ad["val"] = np.array([[10.0, 20.0], [30.0, 40.0]])
-        assert ad.global_range("val") == (10.0, 40.0)
+        assert ad.ranges["val"] == (10.0, 40.0)
 
-    def test_global_labels_2d_categorical(self):
+    def test_labels_2d_categorical(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["site"] = np.array([["alpha", "beta"], ["beta", "gamma"]], dtype=object)
-        assert ad.global_labels("site") == ["alpha", "beta", "gamma"]
+        assert ad.labels["site"] == ["alpha", "beta", "gamma"]
 
-    def test_global_labels_1d_returns_none(self):
+    def test_labels_1d_returns_none(self):
         ad = _make_atom_data(n_atoms=2, n_frames=1)
         ad["site"] = np.array(["alpha", "beta"], dtype=object)
-        assert ad.global_labels("site") is None
+        assert ad.labels["site"] is None
 
-    def test_global_labels_numeric_returns_none(self):
+    def test_labels_numeric_returns_none(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["val"] = np.array([[1.0, 2.0], [3.0, 4.0]])
-        assert ad.global_labels("val") is None
+        assert ad.labels["val"] is None
 
-    def test_global_labels_excludes_missing(self):
+    def test_labels_excludes_missing(self):
         ad = _make_atom_data(n_atoms=3, n_frames=2)
         ad["site"] = np.array([["alpha", None, "beta"],
                                 [None, "alpha", None]], dtype=object)
-        assert ad.global_labels("site") == ["alpha", "beta"]
+        assert ad.labels["site"] == ["alpha", "beta"]
 
-    def test_global_labels_cached(self):
+    def test_labels_updates_on_reassignment(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
         ad["site"] = np.array([["a", "b"], ["b", "a"]], dtype=object)
-        r1 = ad.global_labels("site")
-        r2 = ad.global_labels("site")
-        assert r1 is r2
-
-    def test_global_labels_invalidated_on_set(self):
-        ad = _make_atom_data(n_atoms=2, n_frames=2)
-        ad["site"] = np.array([["a", "b"], ["b", "a"]], dtype=object)
-        assert ad.global_labels("site") == ["a", "b"]
+        assert ad.labels["site"] == ["a", "b"]
         ad["site"] = np.array([["x", "y"], ["y", "x"]], dtype=object)
-        assert ad.global_labels("site") == ["x", "y"]
+        assert ad.labels["site"] == ["x", "y"]
 
-    def test_global_range_partial_nan(self):
+    def test_ranges_partial_nan(self):
         ad = _make_atom_data(n_atoms=3, n_frames=2)
         ad["val"] = np.array([[1.0, np.nan, 3.0], [np.nan, 5.0, np.nan]])
-        assert ad.global_range("val") == (1.0, 5.0)
+        assert ad.ranges["val"] == (1.0, 5.0)
+
+    def test_ranges_is_read_only(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
+        with pytest.raises(TypeError):
+            ad.ranges["val"] = (0.0, 99.0)
+        with pytest.raises(TypeError):
+            del ad.ranges["val"]
+
+    def test_ranges_missing_key_raises(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
+        with pytest.raises(KeyError):
+            ad.ranges["nonexistent"]
+
+    def test_ranges_contains_every_stored_key(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
+        ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
+        ad["flat"] = np.array([0.0, 1.0])
+        assert set(ad.ranges) == set(ad)
+
+    def test_labels_is_read_only(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
+        with pytest.raises(TypeError):
+            ad.labels["site"] = ["x", "y"]
+        with pytest.raises(TypeError):
+            del ad.labels["site"]
+
+    def test_labels_missing_key_raises(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
+        with pytest.raises(KeyError):
+            ad.labels["nonexistent"]
+
+    def test_labels_contains_every_stored_key(self):
+        ad = _make_atom_data(n_atoms=2, n_frames=2)
+        ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
+        ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
+        ad["flat"] = np.array([0.0, 1.0])
+        assert set(ad.labels) == set(ad)
 
     def test_negative_n_atoms_raises(self):
         with pytest.raises(ValueError, match="non-negative"):

--- a/tests/test_model/test_atom_data.py
+++ b/tests/test_model/test_atom_data.py
@@ -161,6 +161,8 @@ class TestAtomData:
         ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
         ad["flat"] = np.array([0.0, 1.0])
         assert set(ad.ranges) == set(ad)
+        del ad["site"]
+        assert set(ad.ranges) == set(ad)
 
     def test_labels_is_read_only(self):
         ad = _make_atom_data(n_atoms=2, n_frames=2)
@@ -181,6 +183,8 @@ class TestAtomData:
         ad["val"] = np.array([[0.0, 1.0], [2.0, 3.0]])
         ad["site"] = np.array([["a", "b"], ["c", "d"]], dtype=object)
         ad["flat"] = np.array([0.0, 1.0])
+        assert set(ad.labels) == set(ad)
+        del ad["val"]
         assert set(ad.labels) == set(ad)
 
     def test_negative_n_atoms_raises(self):

--- a/tests/test_model/test_colour.py
+++ b/tests/test_model/test_colour.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from hofmann.model.atom_style import AtomStyle
-from hofmann.model.colour import normalise_colour, resolve_atom_colours
+from hofmann.model.colour import _resolve_atom_colours, normalise_colour
 
 
 class TestNormaliseColour:
@@ -55,7 +55,7 @@ class TestNormaliseColour:
 
 
 class TestResolveAtomColours:
-    """Tests for resolve_atom_colours."""
+    """Tests for _resolve_atom_colours."""
 
     SPECIES = ["C", "H", "O"]
     STYLES: dict = {
@@ -66,7 +66,7 @@ class TestResolveAtomColours:
 
     def test_species_fallback(self):
         """colour_by=None returns species-based colours."""
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, {},
         )
         assert result == [
@@ -77,7 +77,7 @@ class TestResolveAtomColours:
 
     def test_species_fallback_missing_style(self):
         """Missing species falls back to grey."""
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             ["X"], {}, {},
         )
         assert result == [(0.5, 0.5, 0.5)]
@@ -90,7 +90,7 @@ class TestResolveAtomColours:
         expected_1 = cmap(1.0)[:3]
 
         data = {"val": np.array([0.0, 1.0])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             ["A", "B"], self.STYLES, data,
             colour_by="val", cmap="viridis",
         )
@@ -105,7 +105,7 @@ class TestResolveAtomColours:
         expected = cmap(0.5)[:3]
 
         data = {"val": np.array([5.0])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             ["A"], self.STYLES, data,
             colour_by="val", colour_range=(0.0, 10.0),
         )
@@ -118,7 +118,7 @@ class TestResolveAtomColours:
         expected = cmap(0.5)[:3]
 
         data = {"val": np.array([3.0, 3.0, 3.0])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="val",
         )
         for c in result:
@@ -127,7 +127,7 @@ class TestResolveAtomColours:
     def test_numerical_nan_falls_back(self):
         """NaN entries get their species colour."""
         data = {"val": np.array([0.0, np.nan, 1.0])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="val",
         )
         # Middle atom (H) should get species colour
@@ -138,7 +138,7 @@ class TestResolveAtomColours:
     def test_numerical_all_nan(self):
         """All NaN returns species colours."""
         data = {"val": np.array([np.nan, np.nan, np.nan])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="val",
         )
         assert result == [
@@ -150,7 +150,7 @@ class TestResolveAtomColours:
     def test_categorical_distinct_colours(self):
         """Two categories get two different colours."""
         data = {"site": np.array(["4a", "8b", "4a"], dtype=object)}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="site",
         )
         # Atoms 0 and 2 (both "4a") should have the same colour.
@@ -161,7 +161,7 @@ class TestResolveAtomColours:
     def test_categorical_empty_falls_back(self):
         """Empty string entries get their species colour."""
         data = {"site": np.array(["4a", "", "8b"], dtype=object)}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="site",
         )
         # Middle atom (H, empty label) should get species colour
@@ -173,7 +173,7 @@ class TestResolveAtomColours:
             return (val, 0.0, 1.0 - val)
 
         data = {"val": np.array([0.0, 0.5, 1.0])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by="val", cmap=red_blue,
         )
@@ -183,20 +183,9 @@ class TestResolveAtomColours:
 
     def test_missing_key_raises(self):
         with pytest.raises(KeyError):
-            resolve_atom_colours(
+            _resolve_atom_colours(
                 self.SPECIES, self.STYLES, {},
                 colour_by="nonexistent",
-            )
-
-    def test_unsupported_dtype_raises(self):
-        """Complex (and similar) dtypes raise a clear error rather
-        than silently dropping the imaginary part via astype(float).
-        """
-        data = {"z": np.array([1 + 2j, 3 + 4j, 5 + 6j])}
-        with pytest.raises(ValueError, match="unsupported dtype"):
-            resolve_atom_colours(
-                self.SPECIES, self.STYLES, data,
-                colour_by="z",
             )
 
     def test_list_colour_by_priority(self):
@@ -211,7 +200,7 @@ class TestResolveAtomColours:
             "a": np.array([1.0, np.nan, np.nan]),
             "b": np.array([np.nan, 2.0, np.nan]),
         }
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by=["a", "b"], cmap=[red, blue],
         )
@@ -232,7 +221,7 @@ class TestResolveAtomColours:
             "a": np.array([1.0, np.nan, np.nan]),
             "b": np.array([2.0, 2.0, np.nan]),  # atom 0 in both
         }
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by=["a", "b"], cmap=[red, blue],
         )
@@ -246,7 +235,7 @@ class TestResolveAtomColours:
             "a": np.array([0.0, np.nan, np.nan]),
             "b": np.array([np.nan, 1.0, np.nan]),
         }
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by=["a", "b"], cmap="viridis",
         )
@@ -261,7 +250,7 @@ class TestResolveAtomColours:
             "a": np.array([np.nan, np.nan, np.nan]),
             "b": np.array([np.nan, np.nan, np.nan]),
         }
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by=["a", "b"],
         )
@@ -283,7 +272,7 @@ class TestResolveAtomColours:
             "metal": np.array(["Fe", "", ""], dtype=object),
             "anion": np.array(["", "O", ""], dtype=object),
         }
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by=["metal", "anion"], cmap=[red, blue],
         )
@@ -297,7 +286,7 @@ class TestResolveAtomColours:
         cmap = matplotlib.colormaps["viridis"]
 
         data = {"val": np.array([1, 2, 3])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="val",
         )
         # 1->0.0, 2->0.5, 3->1.0 after normalisation
@@ -308,7 +297,7 @@ class TestResolveAtomColours:
     def test_categorical_nan_falls_back(self):
         """np.nan in categorical data is treated as missing."""
         data = {"site": np.array(["4a", np.nan, "8b"], dtype=object)}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="site",
         )
         # Middle atom (H) should get species colour
@@ -320,7 +309,7 @@ class TestResolveAtomColours:
     def test_categorical_none_falls_back(self):
         """None in categorical data is treated as missing."""
         data = {"site": np.array(["4a", None, "8b"], dtype=object)}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data, colour_by="site",
         )
         # Middle atom (H) should get species colour
@@ -336,7 +325,7 @@ class TestResolveAtomColours:
             "b": np.array([np.nan, 2.0, np.nan]),
         }
         with pytest.raises(ValueError, match="cmap"):
-            resolve_atom_colours(
+            _resolve_atom_colours(
                 self.SPECIES, self.STYLES, data,
                 colour_by=["a", "b"],
                 cmap=["viridis", "plasma", "inferno"],
@@ -349,7 +338,7 @@ class TestResolveAtomColours:
             "b": np.array([np.nan, 2.0, np.nan]),
         }
         with pytest.raises(ValueError, match="colour_range"):
-            resolve_atom_colours(
+            _resolve_atom_colours(
                 self.SPECIES, self.STYLES, data,
                 colour_by=["a", "b"],
                 colour_range=[(0.0, 1.0), (0.0, 2.0), (0.0, 3.0)],
@@ -376,7 +365,7 @@ class TestResolveAtomColours:
             # Layer "b" has data for atom 1.
             "b": np.array([np.nan, 2.0, np.nan]),
         }
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by=["a", "b"], cmap=[grey_cmap, blue],
         )
@@ -391,7 +380,7 @@ class TestResolveAtomColours:
         """List cmap with single colour_by string raises ValueError."""
         data = {"val": np.array([1.0, 2.0, 3.0])}
         with pytest.raises(ValueError, match="cmap"):
-            resolve_atom_colours(
+            _resolve_atom_colours(
                 self.SPECIES, self.STYLES, data,
                 colour_by="val", cmap=["viridis"],
             )
@@ -400,7 +389,7 @@ class TestResolveAtomColours:
         """List colour_range with single colour_by string raises ValueError."""
         data = {"val": np.array([1.0, 2.0, 3.0])}
         with pytest.raises(ValueError, match="colour_range"):
-            resolve_atom_colours(
+            _resolve_atom_colours(
                 self.SPECIES, self.STYLES, data,
                 colour_by="val", colour_range=[(0.0, 1.0)],
             )
@@ -411,14 +400,14 @@ class TestResolveAtomColours:
         cmap_obj = matplotlib.colormaps["viridis"]
 
         data = {"val": np.array([0.0, 0.5, 1.0])}
-        result = resolve_atom_colours(
+        result = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by="val", cmap=cmap_obj,
         )
         for colour in result:
             assert len(colour) == 3
         # Check values match the string-based lookup.
-        expected = resolve_atom_colours(
+        expected = _resolve_atom_colours(
             self.SPECIES, self.STYLES, data,
             colour_by="val", cmap="viridis",
         )

--- a/tests/test_model/test_colour.py
+++ b/tests/test_model/test_colour.py
@@ -188,6 +188,18 @@ class TestResolveAtomColours:
                 colour_by="nonexistent",
             )
 
+    def test_numerical_rejects_non_numeric_dtype(self):
+        """_resolve_numerical's precondition catches non-numeric
+        dtypes at the unsafe values.astype(float) site, even if the
+        upstream AtomData validation is bypassed.
+        """
+        data = {"z": np.array([1 + 2j, 3 + 4j, 5 + 6j])}
+        with pytest.raises(ValueError, match="numeric dtype"):
+            _resolve_atom_colours(
+                self.SPECIES, self.STYLES, data,
+                colour_by="z",
+            )
+
     def test_list_colour_by_priority(self):
         """Non-overlapping layers: each atom gets its layer's colour."""
         def red(_v: float) -> tuple[float, float, float]:

--- a/tests/test_model/test_colour.py
+++ b/tests/test_model/test_colour.py
@@ -188,6 +188,17 @@ class TestResolveAtomColours:
                 colour_by="nonexistent",
             )
 
+    def test_unsupported_dtype_raises(self):
+        """Complex (and similar) dtypes raise a clear error rather
+        than silently dropping the imaginary part via astype(float).
+        """
+        data = {"z": np.array([1 + 2j, 3 + 4j, 5 + 6j])}
+        with pytest.raises(ValueError, match="unsupported dtype"):
+            resolve_atom_colours(
+                self.SPECIES, self.STYLES, data,
+                colour_by="z",
+            )
+
     def test_list_colour_by_priority(self):
         """Non-overlapping layers: each atom gets its layer's colour."""
         def red(_v: float) -> tuple[float, float, float]:


### PR DESCRIPTION
## Summary

Three user-visible changes in 0.18.0, all in the `AtomData` / colour area:

- `AtomData` now computes `global_range` / `global_labels` eagerly in `__setitem__` rather than lazily with cache invalidation. Safe because #64 already freezes stored arrays on assignment, so a value computed at set time stays valid for the lifetime of the stored array. The `global_range(key)` and `global_labels(key)` methods are replaced by read-only `ad.ranges` and `ad.labels` mapping attributes, backed by `MappingProxyType` and typed as `collections.abc.Mapping`. Callers migrate with a direct substitution: `ad.global_range(key)` becomes `ad.ranges[key]`, and `ad.global_labels(key)` becomes `ad.labels[key]`. Closes #68.

- `AtomData.__setitem__` now rejects unsupported dtypes at assignment time with a clear error. Supported dtypes are bool, integer, float, string, and object; complex, datetime, bytes, and other dtypes now raise `ValueError` at assignment rather than failing later in the rendering pipeline.

- `resolve_atom_colours` is no longer part of the public API. Colour resolution goes through the `StructureScene` rendering methods.

Breaking API changes, version bumped to 0.18.0.