### PR TITLE
Document partial occupancy in the user guide

### DIFF
--- a/docs/_static/generate_images.py
+++ b/docs/_static/generate_images.py
@@ -6,9 +6,10 @@ import numpy as np
 from scipy.spatial.transform import Rotation
 
 from hofmann import (
-    AtomLegendItem, AtomStyle, AxesStyle, BondSpec, Frame, LegendStyle,
-    PolygonLegendItem, PolyhedronLegendItem, PolyhedronSpec,
-    RenderStyle, StructureScene, ViewState,
+    AtomLegendItem, AtomStyle, AxesStyle, BondSpec, CellEdgeStyle,
+    Composition, Frame, LegendStyle, PolygonLegendItem,
+    PolyhedronLegendItem, PolyhedronSpec, RenderStyle, StructureScene,
+    ViewState,
 )
 
 OUT = Path(__file__).resolve().parent
@@ -122,6 +123,59 @@ def perovskite_scene() -> StructureScene:
         centre_atom=0,
     )
     _style_perovskite(scene)
+    return scene
+
+
+def partial_occupancy_scene() -> StructureScene:
+    """TiOF2 (ReO3-type) illustrating disordered O / F anion sites.
+
+    TiOF2 adopts a cubic ReO3-type structure with Ti at the cell
+    corners and a single anion site at each edge midpoint, occupied
+    by O and F in a 2:1 ratio.  Every anion site is therefore drawn
+    as a two-wedge mixed-occupancy site.
+    """
+    # Cubic ReO3-type, a approximately 3.80 Angstroms for TiOF2.
+    a = 3.80
+    coords = np.array([
+        [0.0, 0.0, 0.0],   # Ti
+        [0.5, 0.0, 0.0],   # anion (O / F)
+        [0.0, 0.5, 0.0],   # anion
+        [0.0, 0.0, 0.5],   # anion
+    ]) * a
+
+    anion = Composition({"F": 2 / 3, "O": 1 / 3})
+    species: list[str | Composition] = ["Ti", anion, anion, anion]
+
+    bond_specs = [
+        BondSpec(species=("Ti", "O"), min_length=0.5, max_length=2.3,
+                 radius=0.10, colour=(0.4, 0.4, 0.4)),
+        BondSpec(species=("Ti", "F"), min_length=0.5, max_length=2.3,
+                 radius=0.10, colour=(0.4, 0.4, 0.4)),
+    ]
+
+    scene = StructureScene(
+        species=species,
+        frames=[Frame(coords=coords, lattice=np.eye(3) * a)],
+        atom_styles={
+            "Ti": AtomStyle(radius=1.1, colour="#289588"),
+            "O":  AtomStyle(radius=0.9, colour="#DB694D"),
+            "F":  AtomStyle(radius=0.9, colour="#E89A5C"),
+        },
+        bond_specs=bond_specs,
+        title="TiOF$_{2}$",
+    )
+    scene.view.look_along([1, 0.18, 0.2])
+    return scene
+
+
+def disordered_site_scene() -> StructureScene:
+    """Single mixed-occupancy Fe / Mn site loaded from a minimal CIF."""
+    from pymatgen.core import Structure as PmgStructure
+
+    cif_path = Path(__file__).resolve().parent.parent.parent / "examples" / "disordered_site.cif"
+    structure = PmgStructure.from_file(cif_path)
+    scene = StructureScene.from_pymatgen(structure)
+    scene.view.look_along([1, 0.18, 0.2])
     return scene
 
 
@@ -424,6 +478,28 @@ def generate_docs_images() -> None:
         show_outlines=False,
     )
     print(f"  wrote {OUT / 'perovskite_no_outlines.svg'}")
+
+    # Partial / mixed occupancy: TiOF2 hero figure for the user guide.
+    partial = partial_occupancy_scene()
+    partial.render_mpl(
+        OUT / "partial_occupancy.svg",
+        figsize=(5, 5), dpi=150, half_bonds=False,
+        style=RenderStyle(show_axes=False),
+    )
+    print(f"  wrote {OUT / 'partial_occupancy.svg'}")
+
+    # Minimal single-site mixed-occupancy render, paired with the
+    # disordered_site.cif example in the user guide.
+    disordered = disordered_site_scene()
+    disordered.render_mpl(
+        OUT / "partial_occupancy_minimal.svg",
+        figsize=(3, 3), dpi=150,
+        style=RenderStyle(
+            show_axes=False,
+            cell_style=CellEdgeStyle(line_width=1.6),
+        ),
+    )
+    print(f"  wrote {OUT / 'partial_occupancy_minimal.svg'}")
 
     # LLZO garnet with ZrO6 polyhedra and slab clipping
     llzo = llzo_scene()

--- a/docs/_static/generate_images.py
+++ b/docs/_static/generate_images.py
@@ -130,9 +130,9 @@ def partial_occupancy_scene() -> StructureScene:
     """TiOF2 (ReO3-type) illustrating disordered O / F anion sites.
 
     TiOF2 adopts a cubic ReO3-type structure with Ti at the cell
-    corners and a single anion site at each edge midpoint, occupied
-    by O and F in a 2:1 ratio.  Every anion site is therefore drawn
-    as a two-wedge mixed-occupancy site.
+    corners and a single anion site at each edge midpoint.  Every
+    anion site is occupied by F and O in a 2:1 ratio, and is
+    therefore drawn as a two-wedge mixed-occupancy site.
     """
     # Cubic ReO3-type, a approximately 3.80 Angstroms for TiOF2.
     a = 3.80

--- a/docs/_static/generate_images.py
+++ b/docs/_static/generate_images.py
@@ -162,7 +162,6 @@ def partial_occupancy_scene() -> StructureScene:
             "F":  AtomStyle(radius=0.9, colour="#E89A5C"),
         },
         bond_specs=bond_specs,
-        title="TiOF$_{2}$",
     )
     scene.view.look_along([1, 0.18, 0.2])
     return scene
@@ -175,6 +174,28 @@ def disordered_site_scene() -> StructureScene:
     cif_path = Path(__file__).resolve().parent.parent.parent / "examples" / "disordered_site.cif"
     structure = PmgStructure.from_file(cif_path)
     scene = StructureScene.from_pymatgen(structure)
+    scene.view.look_along([1, 0.18, 0.2])
+    return scene
+
+
+def vacancy_site_scene() -> StructureScene:
+    """Single Fe site at 70 % occupancy in a minimal cell.
+
+    Mirrors the layout of :func:`disordered_site_scene` but with a
+    single-species :class:`Composition` summing to less than one, so
+    the rendering shows a vacancy wedge.
+    """
+    a = 2.8
+    scene = StructureScene(
+        species=[Composition({"Fe": 0.7})],
+        frames=[Frame(
+            coords=np.array([[a / 2, a / 2, a / 2]]),
+            lattice=np.eye(3) * a,
+        )],
+        atom_styles={
+            "Fe": AtomStyle(radius=1.32, colour=(0.812, 0.118, 0.067)),
+        },
+    )
     scene.view.look_along([1, 0.18, 0.2])
     return scene
 
@@ -490,16 +511,26 @@ def generate_docs_images() -> None:
 
     # Minimal single-site mixed-occupancy render, paired with the
     # disordered_site.cif example in the user guide.
+    minimal_style = RenderStyle(
+        show_axes=False,
+        cell_style=CellEdgeStyle(line_width=1.6),
+    )
     disordered = disordered_site_scene()
     disordered.render_mpl(
         OUT / "partial_occupancy_minimal.svg",
         figsize=(3, 3), dpi=150,
-        style=RenderStyle(
-            show_axes=False,
-            cell_style=CellEdgeStyle(line_width=1.6),
-        ),
+        style=minimal_style,
     )
     print(f"  wrote {OUT / 'partial_occupancy_minimal.svg'}")
+
+    # Single-site vacancy render for the Vacancies section.
+    vacancy = vacancy_site_scene()
+    vacancy.render_mpl(
+        OUT / "partial_occupancy_vacancy.svg",
+        figsize=(3, 3), dpi=150,
+        style=minimal_style,
+    )
+    print(f"  wrote {OUT / 'partial_occupancy_vacancy.svg'}")
 
     # LLZO garnet with ZrO6 polyhedra and slab clipping
     llzo = llzo_scene()

--- a/docs/_static/generate_images.py
+++ b/docs/_static/generate_images.py
@@ -172,7 +172,7 @@ def disordered_site_scene() -> StructureScene:
     from pymatgen.core import Structure as PmgStructure
 
     cif_path = Path(__file__).resolve().parent.parent.parent / "examples" / "disordered_site.cif"
-    structure = PmgStructure.from_file(cif_path)
+    structure = PmgStructure.from_file(str(cif_path))
     scene = StructureScene.from_pymatgen(structure)
     scene.view.look_along([1, 0.18, 0.2])
     return scene

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -123,4 +123,6 @@ If you have pymatgen installed, you can build a scene directly from a
    :alt: Diamond-cubic Si rendered from pymatgen
 
 See :func:`~hofmann.from_pymatgen` for full details on periodic boundary
-condition expansion and polyhedra support.
+condition expansion and polyhedra support.  Partial-occupancy and
+solid-solution sites pass through automatically -- see
+:doc:`partial_occupancy`.

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -71,8 +71,7 @@ Loading from a CIF file
 -----------------------
 
 CIFs can be loaded with pymatgen and passed through to
-:func:`~hofmann.from_pymatgen`.  For example, this minimal CIF
-defines a single Fe / Mn site filling a 2.8 Å cubic cell:
+:func:`~hofmann.from_pymatgen`.  For example:
 
 .. literalinclude:: ../examples/disordered_site.cif
    :language: text

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -8,6 +8,16 @@ atom) or shared between multiple species (a solid solution).  These
 sites appear as VESTA-style pie wedges, one wedge per constituent
 species, with wedge angles proportional to occupancy.
 
+.. image:: _static/partial_occupancy.svg
+   :width: 400px
+   :align: center
+   :alt: TiOF2 unit cell with disordered O/F anion sites rendered as wedges
+
+The figure above shows TiOF\ :sub:`2`, which adopts the cubic
+ReO\ :sub:`3` structure with Ti at the cell corners and a single anion
+site at each edge midpoint.  Every anion site is occupied by O and F
+in a 2:1 ratio, so each appears as a two-wedge mixed site.
+
 Constructing a mixed site
 --------------------------
 
@@ -17,19 +27,57 @@ the ``species`` list, in place of a plain string label::
     import numpy as np
     from hofmann import Composition, StructureScene, Frame
 
-    fe_mn = Composition({"Fe": 0.7, "Mn": 0.3})
+    anion = Composition({"O": 2 / 3, "F": 1 / 3})
     scene = StructureScene(
-        species=["Fe", fe_mn, fe_mn, "O"],
+        species=["Ti", anion, anion, anion],
         frames=[Frame(coords=np.array([
             [0.0, 0.0, 0.0],
-            [2.0, 0.0, 0.0],
-            [4.0, 0.0, 0.0],
-            [6.0, 0.0, 0.0],
+            [1.9, 0.0, 0.0],
+            [0.0, 1.9, 0.0],
+            [0.0, 0.0, 1.9],
         ]))],
     )
 
 Reusing a single ``Composition`` value across many rows is the
 recommended way to keep authoring concise.
+
+Loading from a CIF file
+-----------------------
+
+CIF files express mixed sites by listing each species at the same
+fractional position with its own occupancy.  pymatgen reads these
+files directly and :func:`~hofmann.from_pymatgen` propagates the
+occupancies through to a :class:`Composition`-bearing scene with no
+manual processing.
+
+Here is the smallest possible example -- a single Fe / Mn site
+filling a 2.8 Å cubic cell:
+
+.. literalinclude:: ../examples/disordered_site.cif
+   :language: text
+   :caption: ``disordered_site.cif``
+
+Loading and rendering takes two lines:
+
+.. code-block:: python
+
+   from pymatgen.core import Structure
+   from hofmann import StructureScene
+
+   structure = Structure.from_file("disordered_site.cif")
+   scene = StructureScene.from_pymatgen(structure)
+   scene.render_mpl("disordered.svg")
+
+.. image:: _static/partial_occupancy_minimal.svg
+   :width: 220px
+   :align: center
+   :alt: Single mixed-occupancy Fe/Mn site rendered as a two-wedge atom
+
+The same pattern applies to any pymatgen :class:`~pymatgen.core.Structure`,
+whether it was read from a CIF file or built programmatically: any
+:class:`pymatgen.core.PeriodicSite` whose ``species`` mapping has
+more than one entry, or a single entry at occupancy less than one,
+becomes a :class:`Composition` in the resulting scene.
 
 Vacancies
 ---------
@@ -45,15 +93,6 @@ solid circles with a "missing" slice.  Set
 :attr:`~hofmann.RenderStyle.vacancy_colour` to override with an
 explicit colour (for example, ``"lightgrey"`` on a white canvas to
 make the vacancy stand out).
-
-Loading from pymatgen
----------------------
-
-:func:`~hofmann.from_pymatgen` propagates partial occupancies
-directly: any :class:`pymatgen.core.PeriodicSite` whose ``species``
-mapping has more than one entry, or a single entry at occupancy less
-than one, becomes a :class:`Composition` in the resulting scene.  No
-preprocessing or manual handling is required.
 
 Customising appearance
 ----------------------
@@ -77,6 +116,17 @@ The wedge layout itself is controlled by three render-style fields:
   outer arc).
 - :attr:`~hofmann.RenderStyle.vacancy_colour` overrides the vacancy
   fill (default: canvas background colour).
+
+For example::
+
+    from hofmann import RenderStyle
+
+    style = RenderStyle(
+        wedge_start_angle=0.0,        # start at 3 o'clock
+        show_wedge_edges=False,       # outer arc only, no radial edges
+        vacancy_colour="lightgrey",   # explicit vacancy fill
+    )
+    scene.render_mpl("structure.svg", style=style)
 
 Visibility of constituent species
 ---------------------------------

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -3,19 +3,17 @@
 Partial and mixed occupancy
 ============================
 
+TiOF\ :sub:`2`
+
 Hofmann can render sites with partial or mixed crystallographic
-occupancy.  Such sites are drawn as pie wedges -- one wedge per
-species, with each wedge's angle equal to that species' occupancy.
+occupancy.  Such *mixed sites* are drawn as pie wedges -- one wedge
+per species, with each wedge's angle equal to that species'
+occupancy.
 
 .. image:: _static/partial_occupancy.svg
    :width: 400px
    :align: center
    :alt: TiOF2 unit cell with disordered O/F anion sites rendered as wedges
-
-The figure above shows TiOF\ :sub:`2`, which adopts the cubic
-ReO\ :sub:`3` structure with Ti at the cell corners and one anion
-site at each edge midpoint.  Each anion site has occupancy 2/3 F and
-1/3 O, so each is drawn as two wedges.
 
 Constructing a mixed site
 --------------------------
@@ -37,29 +35,48 @@ the ``species`` list, in place of a plain string label::
         ]))],
     )
 
-When several sites share the same composition -- as the three anion
-sites do above -- define the :class:`Composition` once and pass the
-same value at each position, rather than constructing a fresh
-identical mix every time.
+Vacancies
+---------
+
+When a :class:`Composition`'s occupancies sum to less than one, the
+missing fraction is treated as a vacancy::
+
+    fe_partial = Composition({"Fe": 0.7})  # 70% Fe, 30% vacancy
+
+.. image:: _static/partial_occupancy_vacancy.svg
+   :width: 220px
+   :align: center
+   :alt: Single Fe site at 70 percent occupancy with a vacancy wedge
+
+The vacancy wedge is filled with the canvas background colour by
+default.  A custom vacancy colour can be set by passing the
+:attr:`~hofmann.RenderStyle.vacancy_colour` field on
+:class:`~hofmann.RenderStyle`.
+
+From a pymatgen Structure
+-------------------------
+
+pymatgen represents partial occupancy and species disorder natively.
+:func:`~hofmann.from_pymatgen` reads this directly: any site with
+more than one species, or with a single species at occupancy below
+one, becomes a :class:`Composition` in the resulting scene.
+
+.. code-block:: python
+
+   from hofmann import StructureScene
+
+   scene = StructureScene.from_pymatgen(structure)
+   scene.render_mpl("output.svg")
 
 Loading from a CIF file
 -----------------------
 
-CIF files express mixed sites by listing each species on its own row
-at the same fractional position, with the row's occupancy giving that
-species' fraction.  pymatgen reads these directly, and
-:func:`~hofmann.from_pymatgen` turns each such site into a
-:class:`Composition` in the resulting scene -- you don't need to
-preprocess the structure.
-
-Here is a minimal example -- a single Fe / Mn site filling a 2.8 Å
-cubic cell:
+CIFs are loaded by pymatgen and passed through to
+:func:`~hofmann.from_pymatgen`.  Here is a minimal example -- a
+single Fe / Mn site filling a 2.8 Å cubic cell:
 
 .. literalinclude:: ../examples/disordered_site.cif
    :language: text
-   :caption: ``disordered_site.cif``
-
-Load it and render:
 
 .. code-block:: python
 
@@ -75,27 +92,6 @@ Load it and render:
    :align: center
    :alt: Single mixed-occupancy Fe/Mn site rendered as a two-wedge atom
 
-The same conversion applies to any pymatgen :class:`~pymatgen.core.Structure`,
-whether you read it from a CIF or built it in code.  The rule is
-simple: any site with more than one species, or with a single species
-at occupancy below one, becomes a :class:`Composition`.  Everything
-else stays as a plain species label.
-
-Vacancies
----------
-
-When a :class:`Composition`'s occupancies sum to less than one, the
-missing fraction is treated as a vacancy::
-
-    fe_partial = Composition({"Fe": 0.7})  # 70% Fe, 30% vacancy
-
-The vacancy is drawn as an opaque wedge filled with the canvas
-background colour, so the site still reads as a solid circle with a
-"missing" slice rather than a hole.  Override the fill with
-:attr:`~hofmann.RenderStyle.vacancy_colour` -- for example,
-``"lightgrey"`` on a white canvas if you want vacancies to be
-visible at a glance.
-
 Customising appearance
 ----------------------
 
@@ -103,15 +99,12 @@ Each wedge takes its colour from the species'
 :attr:`~hofmann.AtomStyle.colour`.  The radius of the whole site is
 the occupancy-weighted average of its constituents' radii, with the
 average computed over the occupied species only -- so a half-vacant
-site is drawn at the same size as a fully occupied one, not half the
-size.
+site is drawn at the same size as a fully occupied one.
 
 For more specific styling -- for example, colouring all mixed sites
 the same way to flag disordered positions -- attach per-site data
 with :meth:`~hofmann.StructureScene.set_atom_data` and use the
-``colour_by`` parameter when rendering.  This is the same workflow
-described in :doc:`colouring`; mixed sites participate just like
-single-species sites.
+``colour_by`` parameter when rendering.  See :doc:`colouring`.
 
 Three :class:`~hofmann.RenderStyle` fields control the wedge layout:
 
@@ -142,13 +135,6 @@ site whose species is given as a plain label.  It does **not** hide
 that species when it appears as a constituent of a
 :class:`Composition`: a mixed site is always drawn with all of its
 constituents, regardless of any per-species ``visible`` flag.
-
-This is deliberate.  The constituents of a mixed site still
-participate in bond rules and polyhedron rules, and rendering only
-some of the wedges would leave the visible site out of step with the
-bonds drawn around it.  To de-emphasise specific mixed sites, attach
-per-site data with :meth:`~hofmann.StructureScene.set_atom_data` and
-recolour them via ``colour_by``.
 
 Bonding and polyhedra
 ---------------------

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -3,17 +3,15 @@
 Partial and mixed occupancy
 ============================
 
-TiOF\ :sub:`2`
+.. image:: _static/partial_occupancy.svg
+ :width: 400px
+ :align: center
+ :alt: TiOF2 unit cell with disordered O/F anion sites rendered as wedges
 
 Hofmann can render sites with partial or mixed crystallographic
-occupancy.  Such *mixed sites* are drawn as pie wedges -- one wedge
+occupancy.  Such *mixed sites* are drawn as pie wedges; one wedge
 per species, with each wedge's angle equal to that species'
 occupancy.
-
-.. image:: _static/partial_occupancy.svg
-   :width: 400px
-   :align: center
-   :alt: TiOF2 unit cell with disordered O/F anion sites rendered as wedges
 
 Constructing a mixed site
 --------------------------
@@ -39,7 +37,7 @@ Vacancies
 ---------
 
 When a :class:`Composition`'s occupancies sum to less than one, the
-missing fraction is treated as a vacancy::
+missing fraction is treated as a vacancy fraction::
 
     fe_partial = Composition({"Fe": 0.7})  # 70% Fe, 30% vacancy
 
@@ -56,7 +54,8 @@ default.  A custom vacancy colour can be set by passing the
 From a pymatgen Structure
 -------------------------
 
-pymatgen represents partial occupancy and species disorder natively.
+A pymatgen :class:`~pymatgen.core.Structure` represents partial
+occupancy and species disorder natively.
 :func:`~hofmann.from_pymatgen` reads this directly: any site with
 more than one species, or with a single species at occupancy below
 one, becomes a :class:`Composition` in the resulting scene.
@@ -71,9 +70,9 @@ one, becomes a :class:`Composition` in the resulting scene.
 Loading from a CIF file
 -----------------------
 
-CIFs are loaded by pymatgen and passed through to
-:func:`~hofmann.from_pymatgen`.  Here is a minimal example -- a
-single Fe / Mn site filling a 2.8 Å cubic cell:
+CIFs can be loaded with pymatgen and passed through to
+:func:`~hofmann.from_pymatgen`.  For example, this minimal CIF
+defines a single Fe / Mn site filling a 2.8 Å cubic cell:
 
 .. literalinclude:: ../examples/disordered_site.cif
    :language: text
@@ -95,16 +94,11 @@ single Fe / Mn site filling a 2.8 Å cubic cell:
 Customising appearance
 ----------------------
 
-Each wedge takes its colour from the species'
+Each wedge takes its colour from the corresponding species'
 :attr:`~hofmann.AtomStyle.colour`.  The radius of the whole site is
 the occupancy-weighted average of its constituents' radii, with the
 average computed over the occupied species only -- so a half-vacant
 site is drawn at the same size as a fully occupied one.
-
-For more specific styling -- for example, colouring all mixed sites
-the same way to flag disordered positions -- attach per-site data
-with :meth:`~hofmann.StructureScene.set_atom_data` and use the
-``colour_by`` parameter when rendering.  See :doc:`colouring`.
 
 Three :class:`~hofmann.RenderStyle` fields control the wedge layout:
 
@@ -126,6 +120,11 @@ For example::
         vacancy_colour="lightgrey",   # explicit vacancy fill
     )
     scene.render_mpl("structure.svg", style=style)
+
+For more specific styling -- for example, colouring all mixed sites
+the same way to flag disordered positions -- attach per-site data
+with :meth:`~hofmann.StructureScene.set_atom_data` and use the
+``colour_by`` parameter when rendering.  See :doc:`colouring`.
 
 Visibility of constituent species
 ---------------------------------

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -3,10 +3,9 @@
 Partial and mixed occupancy
 ============================
 
-Hofmann can render sites with partial crystallographic occupancy or
-sites shared between multiple species (a solid solution).  Such sites
-are drawn as pie wedges -- one wedge per species, with each wedge's
-angle equal to that species' occupancy.
+Hofmann can render sites with partial or mixed crystallographic
+occupancy.  Such sites are drawn as pie wedges -- one wedge per
+species, with each wedge's angle equal to that species' occupancy.
 
 .. image:: _static/partial_occupancy.svg
    :width: 400px

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -3,14 +3,10 @@
 Partial and mixed occupancy
 ============================
 
-Some crystal structures have sites whose atomic identity is not
-fixed across the lattice -- either a species occupies a site in only
-some fraction of unit cells (partial occupancy), or several species
-share the site (a solid solution).  Each individual site still
-contains at most one atom; what varies is which atom, or whether one
-is present at all, from one unit cell to the next.  Hofmann draws
-such sites as pie wedges -- one wedge per species, with each wedge's
-angle equal to that species' crystallographic occupancy.
+Hofmann can render sites with partial crystallographic occupancy or
+sites shared between multiple species (a solid solution).  Such sites
+are drawn as pie wedges -- one wedge per species, with each wedge's
+angle equal to that species' occupancy.
 
 .. image:: _static/partial_occupancy.svg
    :width: 400px
@@ -19,10 +15,8 @@ angle equal to that species' crystallographic occupancy.
 
 The figure above shows TiOF\ :sub:`2`, which adopts the cubic
 ReO\ :sub:`3` structure with Ti at the cell corners and one anion
-site at each edge midpoint.  Across the crystal, two-thirds of these
-positions hold an F atom and one-third hold an O.  The wedges show
-that average: an individual site contains one atom, but the rendering
-draws each site as a 2/3 F, 1/3 O mix.
+site at each edge midpoint.  Each anion site has occupancy 2/3 F and
+1/3 O, so each is drawn as two wedges.
 
 Constructing a mixed site
 --------------------------

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -22,15 +22,18 @@ the ``species`` list, in place of a plain string label::
     import numpy as np
     from hofmann import Composition, StructureScene, Frame
 
-    anion = Composition({"O": 2 / 3, "F": 1 / 3})
+    anion = Composition({"F": 2 / 3, "O": 1 / 3})
     scene = StructureScene(
         species=["Ti", anion, anion, anion],
-        frames=[Frame(coords=np.array([
-            [0.0, 0.0, 0.0],
-            [1.9, 0.0, 0.0],
-            [0.0, 1.9, 0.0],
-            [0.0, 0.0, 1.9],
-        ]))],
+        frames=[Frame(
+            coords=np.array([
+                [0.0, 0.0, 0.0],
+                [1.9, 0.0, 0.0],
+                [0.0, 1.9, 0.0],
+                [0.0, 0.0, 1.9],
+            ]),
+            lattice=np.eye(3) * 3.8,
+        )],
     )
 
 Vacancies
@@ -44,7 +47,7 @@ missing fraction is treated as a vacancy fraction::
 .. image:: _static/partial_occupancy_vacancy.svg
    :width: 220px
    :align: center
-   :alt: Single Fe site at 70 percent occupancy with a vacancy wedge
+   :alt: Single Fe site at 70% occupancy with a vacancy wedge
 
 The vacancy wedge is filled with the canvas background colour by
 default.  A custom vacancy colour can be set by passing the
@@ -64,6 +67,7 @@ one, becomes a :class:`Composition` in the resulting scene.
 
    from hofmann import StructureScene
 
+   # 'structure' is any pymatgen Structure
    scene = StructureScene.from_pymatgen(structure)
    scene.render_mpl("output.svg")
 
@@ -96,8 +100,8 @@ Customising appearance
 Each wedge takes its colour from the corresponding species'
 :attr:`~hofmann.AtomStyle.colour`.  The radius of the whole site is
 the occupancy-weighted average of its constituents' radii, with the
-average computed over the occupied species only -- so a half-vacant
-site is drawn at the same size as a fully occupied one.
+weights renormalised over the occupied species only -- so a
+half-vacant site is drawn at the same size as a fully occupied one.
 
 Three :class:`~hofmann.RenderStyle` fields control the wedge layout:
 
@@ -142,7 +146,8 @@ mixed site whenever any of its constituent species matches the rule.
 Each pair of atoms still produces at most one bond, even when several
 rules match: for a 70 / 30 Fe / Mn site bonded to an O neighbour,
 defining both ``("Fe", "O")`` and ``("Mn", "O")`` rules gives one
-bond, not two.  Vacancies never form bonds.
+bond, not two.  When more than one rule matches a pair, the first in
+list order wins.  Vacancies never form bonds.
 
 The half-bond at the mixed-site end is drawn in the colour of the
 dominant species -- the constituent with the highest occupancy, with

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -38,8 +38,10 @@ the ``species`` list, in place of a plain string label::
         ]))],
     )
 
-Reusing a single ``Composition`` value across many rows is the
-recommended way to keep authoring concise.
+When several sites share the same composition -- as the three anion
+sites do above -- define the :class:`Composition` once and pass the
+same value at each position, rather than constructing a fresh
+identical mix every time.
 
 Loading from a CIF file
 -----------------------

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -3,10 +3,10 @@
 Partial and mixed occupancy
 ============================
 
-Hofmann can render sites that are partially occupied (a fraction of an
-atom) or shared between multiple species (a solid solution).  These
-sites appear as VESTA-style pie wedges, one wedge per constituent
-species, with wedge angles proportional to occupancy.
+Hofmann can render sites that are partially occupied (a fraction of
+an atom) or shared between multiple species (a solid solution).  Such
+sites are drawn as pie wedges -- one wedge per species, with each
+wedge's angle proportional to that species' occupancy.
 
 .. image:: _static/partial_occupancy.svg
    :width: 400px
@@ -14,9 +14,9 @@ species, with wedge angles proportional to occupancy.
    :alt: TiOF2 unit cell with disordered O/F anion sites rendered as wedges
 
 The figure above shows TiOF\ :sub:`2`, which adopts the cubic
-ReO\ :sub:`3` structure with Ti at the cell corners and a single anion
-site at each edge midpoint.  Every anion site is occupied by O and F
-in a 2:1 ratio, so each appears as a two-wedge mixed site.
+ReO\ :sub:`3` structure with Ti at the cell corners and one anion
+site at each edge midpoint.  Each anion site is two-thirds F and
+one-third O, so each is drawn as two wedges.
 
 Constructing a mixed site
 --------------------------
@@ -46,20 +46,21 @@ identical mix every time.
 Loading from a CIF file
 -----------------------
 
-CIF files express mixed sites by listing each species at the same
-fractional position with its own occupancy.  pymatgen reads these
-files directly and :func:`~hofmann.from_pymatgen` propagates the
-occupancies through to a :class:`Composition`-bearing scene with no
-manual processing.
+CIF files express mixed sites by listing each species on its own row
+at the same fractional position, with the row's occupancy giving that
+species' fraction.  pymatgen reads these directly, and
+:func:`~hofmann.from_pymatgen` turns each such site into a
+:class:`Composition` in the resulting scene -- you don't need to
+preprocess the structure.
 
-Here is the smallest possible example -- a single Fe / Mn site
-filling a 2.8 Å cubic cell:
+Here is a minimal example -- a single Fe / Mn site filling a 2.8 Å
+cubic cell:
 
 .. literalinclude:: ../examples/disordered_site.cif
    :language: text
    :caption: ``disordered_site.cif``
 
-Loading and rendering takes two lines:
+Load it and render:
 
 .. code-block:: python
 
@@ -75,41 +76,45 @@ Loading and rendering takes two lines:
    :align: center
    :alt: Single mixed-occupancy Fe/Mn site rendered as a two-wedge atom
 
-The same pattern applies to any pymatgen :class:`~pymatgen.core.Structure`,
-whether it was read from a CIF file or built programmatically: any
-:class:`pymatgen.core.PeriodicSite` whose ``species`` mapping has
-more than one entry, or a single entry at occupancy less than one,
-becomes a :class:`Composition` in the resulting scene.
+The same conversion applies to any pymatgen :class:`~pymatgen.core.Structure`,
+whether you read it from a CIF or built it in code.  The rule is
+simple: any site with more than one species, or with a single species
+at occupancy below one, becomes a :class:`Composition`.  Everything
+else stays as a plain species label.
 
 Vacancies
 ---------
 
-A :class:`Composition` whose occupancies sum to less than one carries
-an implicit vacancy fraction::
+When a :class:`Composition`'s occupancies sum to less than one, the
+missing fraction is treated as a vacancy::
 
-    fe_partial = Composition({"Fe": 0.7})  # 70% Fe + 30% vacancy
+    fe_partial = Composition({"Fe": 0.7})  # 70% Fe, 30% vacancy
 
-The vacancy fraction renders as an opaque wedge filled with the
-canvas background colour by default, so partial sites still read as
-solid circles with a "missing" slice.  Set
-:attr:`~hofmann.RenderStyle.vacancy_colour` to override with an
-explicit colour (for example, ``"lightgrey"`` on a white canvas to
-make the vacancy stand out).
+The vacancy is drawn as an opaque wedge filled with the canvas
+background colour, so the site still reads as a solid circle with a
+"missing" slice rather than a hole.  Override the fill with
+:attr:`~hofmann.RenderStyle.vacancy_colour` -- for example,
+``"lightgrey"`` on a white canvas if you want vacancies to be
+visible at a glance.
 
 Customising appearance
 ----------------------
 
-By default a mixed site is drawn at a radius equal to the
-occupancy-weighted average of its constituents'
-:attr:`~hofmann.AtomStyle.radius`, normalised by the total species
-occupancy so that vacancy fractions do not shrink the site.  Each
-wedge uses its species' :attr:`~hofmann.AtomStyle.colour`.
-For more specific styling — for example, colouring all mixed sites the
-same way to highlight disordered positions — use
-:meth:`~hofmann.StructureScene.set_atom_data` and the ``colour_by``
-parameter of the render methods, exactly as for pure sites.
+Each wedge takes its colour from the species'
+:attr:`~hofmann.AtomStyle.colour`.  The radius of the whole site is
+the occupancy-weighted average of its constituents' radii, with the
+average computed over the occupied species only -- so a half-vacant
+site is drawn at the same size as a fully occupied one, not half the
+size.
 
-The wedge layout itself is controlled by three render-style fields:
+For more specific styling -- for example, colouring all mixed sites
+the same way to flag disordered positions -- attach per-site data
+with :meth:`~hofmann.StructureScene.set_atom_data` and use the
+``colour_by`` parameter when rendering.  This is the same workflow
+described in :doc:`colouring`; mixed sites participate just like
+single-species sites.
+
+Three :class:`~hofmann.RenderStyle` fields control the wedge layout:
 
 - :attr:`~hofmann.RenderStyle.wedge_start_angle` sets the starting
   orientation (default 12 o'clock).
@@ -133,28 +138,29 @@ For example::
 Visibility of constituent species
 ---------------------------------
 
-:attr:`~hofmann.AtomStyle.visible` is a per-species flag — setting it
-to ``False`` hides every pure-string site of that species.  It does
-**not** apply to constituents of a :class:`Composition`: a mixed site
-is always drawn with all of its constituents, regardless of any
-constituent's ``visible`` flag.  This avoids the visually inconsistent
-state where a constituent is hidden in the wedge rendering but its
-species still attracts bonds and matches rule lookups.  To
-de-emphasise specific mixed sites, use
-:meth:`~hofmann.StructureScene.set_atom_data` with ``colour_by`` to
-recolour them at the row level.
+Setting :attr:`~hofmann.AtomStyle.visible` to ``False`` hides every
+site whose species is given as a plain label.  It does **not** hide
+that species when it appears as a constituent of a
+:class:`Composition`: a mixed site is always drawn with all of its
+constituents, regardless of any per-species ``visible`` flag.
+
+This is deliberate.  The constituents of a mixed site still
+participate in bond rules and polyhedron rules, and rendering only
+some of the wedges would leave the visible site out of step with the
+bonds drawn around it.  To de-emphasise specific mixed sites, attach
+per-site data with :meth:`~hofmann.StructureScene.set_atom_data` and
+recolour them via ``colour_by``.
 
 Bonding and polyhedra
 ---------------------
 
-:class:`BondSpec` and :class:`PolyhedronSpec` rules fire on a mixed
-site whenever any constituent species satisfies the rule.  A 70 / 30
-Fe / Mn site with both ``("Fe", "O")`` and ``("Mn", "O")`` bond rules
-defined produces exactly one bond per neighbour, drawn at whichever
-matching cutoff is permissive enough.  Vacancy fractions never
-participate in bonding.
+A :class:`BondSpec` or :class:`PolyhedronSpec` rule applies to a
+mixed site whenever any of its constituent species matches the rule.
+Each pair of atoms still produces at most one bond, even when several
+rules match: for a 70 / 30 Fe / Mn site bonded to an O neighbour,
+defining both ``("Fe", "O")`` and ``("Mn", "O")`` rules gives one
+bond, not two.  Vacancies never form bonds.
 
-The half-bond at a mixed-site end uses the dominant species'
-colour — the species with the highest occupancy in the composition,
-with alphabetical tiebreak.  The wedges, not the bond, communicate the
-full composition.
+The half-bond at the mixed-site end is drawn in the colour of the
+dominant species -- the constituent with the highest occupancy, with
+ties broken alphabetically.

--- a/docs/partial_occupancy.rst
+++ b/docs/partial_occupancy.rst
@@ -3,10 +3,14 @@
 Partial and mixed occupancy
 ============================
 
-Hofmann can render sites that are partially occupied (a fraction of
-an atom) or shared between multiple species (a solid solution).  Such
-sites are drawn as pie wedges -- one wedge per species, with each
-wedge's angle proportional to that species' occupancy.
+Some crystal structures have sites whose atomic identity is not
+fixed across the lattice -- either a species occupies a site in only
+some fraction of unit cells (partial occupancy), or several species
+share the site (a solid solution).  Each individual site still
+contains at most one atom; what varies is which atom, or whether one
+is present at all, from one unit cell to the next.  Hofmann draws
+such sites as pie wedges -- one wedge per species, with each wedge's
+angle equal to that species' crystallographic occupancy.
 
 .. image:: _static/partial_occupancy.svg
    :width: 400px
@@ -15,8 +19,10 @@ wedge's angle proportional to that species' occupancy.
 
 The figure above shows TiOF\ :sub:`2`, which adopts the cubic
 ReO\ :sub:`3` structure with Ti at the cell corners and one anion
-site at each edge midpoint.  Each anion site is two-thirds F and
-one-third O, so each is drawn as two wedges.
+site at each edge midpoint.  Across the crystal, two-thirds of these
+positions hold an F atom and one-third hold an O.  The wedges show
+that average: an individual site contains one atom, but the rendering
+draws each site as a 2/3 F, 1/3 O mix.
 
 Constructing a mixed site
 --------------------------

--- a/docs/scenes.rst
+++ b/docs/scenes.rst
@@ -58,6 +58,11 @@ their corresponding classmethods):
 - ``atom_data`` -- per-atom metadata arrays for colourmap rendering
   (see :doc:`colouring`).
 
+Sites with multiple species or fractional occupancy are also
+supported: pass a :class:`~hofmann.Composition` value in place of a
+species label, and the renderer draws the site as VESTA-style pie
+wedges.  See :doc:`partial_occupancy` for the full guide.
+
 
 Bonds
 -----

--- a/examples/disordered_site.cif
+++ b/examples/disordered_site.cif
@@ -1,4 +1,5 @@
 data_disordered_site
+_chemical_formula_sum    'Fe0.7 Mn0.3'
 _cell_length_a       2.8
 _cell_length_b       2.8
 _cell_length_c       2.8

--- a/examples/disordered_site.cif
+++ b/examples/disordered_site.cif
@@ -1,0 +1,24 @@
+data_disordered_site
+_cell_length_a       2.8
+_cell_length_b       2.8
+_cell_length_c       2.8
+_cell_angle_alpha    90.0
+_cell_angle_beta     90.0
+_cell_angle_gamma    90.0
+
+_space_group_name_H-M_alt    'P 1'
+_space_group_IT_number       1
+
+loop_
+  _space_group_symop_operation_xyz
+  'x, y, z'
+
+loop_
+  _atom_site_type_symbol
+  _atom_site_label
+  _atom_site_fract_x
+  _atom_site_fract_y
+  _atom_site_fract_z
+  _atom_site_occupancy
+  Fe  Fe1  0.5  0.5  0.5  0.7
+  Mn  Mn1  0.5  0.5  0.5  0.3


### PR DESCRIPTION
## Summary

- Rewrites the partial-occupancy guide around a TiOF2 hero figure plus a minimal Fe/Mn CIF worked example
- Restructures the section ordering: programmatic Composition -> vacancies -> pymatgen Structure -> CIF -> styling -> visibility -> bonding
- Adds a vacancy figure (single Fe site at 70 % occupancy)
- Cross-references the partial-occupancy guide from the scene-construction and getting-started pages so the feature is reachable from common entry points
- Adds examples/disordered_site.cif as the inlined minimal CIF